### PR TITLE
Add pytest requirements and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,17 @@ Or use DBeaver/psql to introspect the schema.
 
 ---
 
+## Testing
+
+Functional tests are written in Python and executed with [pytest](https://docs.pytest.org/).
+After installing the dependencies from `requirements.txt`, run:
+
+```bash
+pytest
+```
+
+---
+
 ## License
 
 Licensed under either of:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 sqlglot==26.16.2
 sqlparse==0.5.3
 psycopg==3.2.6
+pytest==8.2.0
+pytest-cov==4.1.0


### PR DESCRIPTION
## Summary
- add pytest and pytest-cov to requirements
- document how to run Python functional tests with pytest

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement pytest==8.2.0)*
- `python -m unittest discover -s .` *(fails: connection refused)*