### PR TITLE
Add pggetone UDF tests and fix planner

### DIFF
--- a/src/clean_duplicate_columns.rs
+++ b/src/clean_duplicate_columns.rs
@@ -131,7 +131,10 @@ fn walk_query(query: &mut Query, counter: &mut usize, alias_map: &mut HashMap<St
 
 pub fn alias_all_columns(sql: &str) -> (String, HashMap<String, String>){
     let dialect = PostgreSqlDialect {};
-    let mut statements = Parser::parse_sql(&dialect, sql).unwrap();
+    let mut statements = match Parser::parse_sql(&dialect, sql) {
+        Ok(s) => s,
+        Err(_) => return (sql.to_string(), HashMap::new()),
+    };
 
     let mut alias_map = HashMap::new();
     let mut counter = 1;

--- a/src/replace.rs
+++ b/src/replace.rs
@@ -48,7 +48,10 @@ fn add_namespace_to_set_command(obj: &mut ObjectName) {
 
 pub fn replace_set_command_with_namespace(sql: &str) -> String {
     let dialect = PostgreSqlDialect {};
-    let mut statements = Parser::parse_sql(&dialect, sql).unwrap();
+    let mut statements = match Parser::parse_sql(&dialect, sql) {
+        Ok(stmts) => stmts,
+        Err(_) => return sql.to_string(),
+    };
 
     visit_statements_mut(&mut statements, |stmt| {
         if let Statement::SetVariable { variables, .. } = stmt {
@@ -91,7 +94,10 @@ pub fn replace_regclass(sql: &str) -> String {
     }
 
     let dialect = PostgreSqlDialect {};
-    let mut statements = Parser::parse_sql(&dialect, sql).unwrap();
+    let mut statements = match Parser::parse_sql(&dialect, sql) {
+        Ok(stmts) => stmts,
+        Err(_) => return sql.to_string(),
+    };
 
     visit_statements_mut(&mut statements, |stmt| {
         visit_expressions_mut(stmt, |expr| {
@@ -165,7 +171,10 @@ pub fn rewrite_pg_custom_operator(sql: &str) -> String {
     use std::ops::ControlFlow;
 
     let dialect = PostgreSqlDialect {};
-    let mut statements = Parser::parse_sql(&dialect, sql).unwrap();
+    let mut statements = match Parser::parse_sql(&dialect, sql) {
+        Ok(stmts) => stmts,
+        Err(_) => return sql.to_string(),
+    };
 
     visit_statements_mut(&mut statements, |stmt| {
         visit_expressions_mut(stmt, |expr| {
@@ -204,7 +213,10 @@ pub fn rewrite_schema_qualified_text(sql: &str) -> String {
     }
 
     let dialect = PostgreSqlDialect {};
-    let mut stmts = Parser::parse_sql(&dialect, sql).unwrap();
+    let mut stmts = match Parser::parse_sql(&dialect, sql) {
+        Ok(s) => s,
+        Err(_) => return sql.to_string(),
+    };
 
     visit_statements_mut(&mut stmts, |stmt| {
         visit_expressions_mut(stmt, |e| {
@@ -244,7 +256,10 @@ pub fn rewrite_schema_qualified_custom_types(sql: &str) -> String {
     }
 
     let dialect = PostgreSqlDialect {};
-    let mut stmts = Parser::parse_sql(&dialect, sql).unwrap();
+    let mut stmts = match Parser::parse_sql(&dialect, sql) {
+        Ok(s) => s,
+        Err(_) => return sql.to_string(),
+    };
 
     visit_statements_mut(&mut stmts, |stmt| {
         visit_expressions_mut(stmt, |e| {
@@ -296,7 +311,10 @@ pub fn rewrite_regtype_cast(sql: &str) -> String {
     }
 
     let dialect = PostgreSqlDialect {};
-    let mut stmts = Parser::parse_sql(&dialect, sql).unwrap();
+    let mut stmts = match Parser::parse_sql(&dialect, sql) {
+        Ok(s) => s,
+        Err(_) => return sql.to_string(),
+    };
 
     visit_statements_mut(&mut stmts, |stmt| {
         visit_expressions_mut(stmt, |e| {
@@ -343,7 +361,10 @@ pub fn strip_default_collate(sql: &str) -> String {
     }
 
     let dialect = PostgreSqlDialect {};
-    let mut statements = Parser::parse_sql(&dialect, sql).unwrap();
+    let mut statements = match Parser::parse_sql(&dialect, sql) {
+        Ok(stmts) => stmts,
+        Err(_) => return sql.to_string(),
+    };
 
     visit_statements_mut(&mut statements, |stmt| {
         visit_expressions_mut(stmt, |e| {

--- a/src/server.rs
+++ b/src/server.rs
@@ -31,7 +31,7 @@ use datafusion::{
 
 use crate::replace::{regclass_udfs, replace_set_command_with_namespace};
 use crate::session::{execute_sql, ClientOpts};
-use crate::user_functions::{register_current_schema, register_scalar_array_to_string, register_scalar_format_type, register_scalar_pg_encoding_to_char, register_scalar_pg_get_expr, register_scalar_pg_get_partkeydef, register_scalar_pg_get_userbyid, register_scalar_pg_table_is_visible, register_scalar_pg_tablespace_location, register_scalar_regclass_oid};
+use crate::user_functions::{register_current_schema, register_pggetone, register_scalar_array_to_string, register_scalar_format_type, register_scalar_pg_encoding_to_char, register_scalar_pg_get_expr, register_scalar_pg_get_partkeydef, register_scalar_pg_get_userbyid, register_scalar_pg_table_is_visible, register_scalar_pg_tablespace_location, register_scalar_regclass_oid};
 use tokio::net::TcpStream;
 use tokio::io::AsyncReadExt;
 use tokio::io::AsyncWriteExt;
@@ -577,6 +577,7 @@ pub async fn start_server(base_ctx: Arc<SessionContext>, addr: &str,
             register_scalar_pg_get_userbyid(&ctx)?;
             register_scalar_pg_encoding_to_char(&ctx)?;
             register_scalar_array_to_string(&ctx)?;
+            register_pggetone(&ctx)?;
             
             let df = ctx.sql("SELECT datname FROM pg_catalog.pg_database where datname='pgtry'").await?;
             if df.count().await? == 0 {

--- a/src/user_functions.rs
+++ b/src/user_functions.rs
@@ -659,6 +659,40 @@ pub fn register_scalar_array_to_string(ctx: &SessionContext) -> Result<()> {
     Ok(())
 }
 
+pub fn register_pggetone(ctx: &SessionContext) -> Result<()> {
+    use arrow::datatypes::DataType;
+    use datafusion::logical_expr::{
+        ColumnarValue, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature,
+        Volatility,
+    };
+
+    #[derive(Debug)]
+    struct PgGetOne { sig: Signature }
+
+    impl PgGetOne {
+        fn new() -> Self {
+            Self { sig: Signature::any(1, Volatility::Stable) }
+        }
+    }
+
+    impl ScalarUDFImpl for PgGetOne {
+        fn as_any(&self) -> &dyn std::any::Any { self }
+        fn name(&self) -> &str { "pggetone" }
+        fn signature(&self) -> &Signature { &self.sig }
+        fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
+            Ok(arg_types.get(0).cloned().unwrap_or(DataType::Null))
+        }
+        fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+            Ok(args.args.into_iter().next().unwrap())
+        }
+    }
+
+    let udf = ScalarUDF::new_from_impl(PgGetOne::new())
+        .with_aliases(["pg_catalog.pggetone"]);
+    ctx.register_udf(udf);
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -778,5 +812,20 @@ mod tests {
         assert!(batches[0].column(0).as_any().downcast_ref::<Int64Array>().unwrap().is_null(0));
         Ok(())
     }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_pggetone_with_subquery() -> Result<()> {
+        let ctx = make_ctx().await?;
+        register_pggetone(&ctx)?;
+        let batches = ctx
+            .sql("SELECT pggetone((SELECT oid FROM pg_catalog.pg_class LIMIT 1)) AS v;")
+            .await?
+            .collect()
+            .await?;
+        let col = batches[0].column(0).as_any().downcast_ref::<Int64Array>().unwrap();
+        assert_eq!(col.value(0), 2606);
+        Ok(())
+    }
+
 
 }

--- a/test_col_types_query.py
+++ b/test_col_types_query.py
@@ -34,7 +34,7 @@ class TestPsycopgQueries(unittest.TestCase):
                 "127.0.0.1",
                 "--port",
                 str(port),
-            ], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            ], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
             conninfo = f"host=127.0.0.1 port={port} dbname=postgres password=pencil sslmode=disable"
             for _ in range(8):
                 try:

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -57,3 +57,10 @@ def test_parameter_query(server):
         )
         row = cur.fetchone()
         assert row[0] >= 1
+
+def test_pggetone_subquery(server):
+    with psycopg.connect(CONN_STR) as conn:
+        cur = conn.cursor()
+        cur.execute("SELECT pggetone((select relname FROM pg_catalog.pg_class LIMIT 1))")
+        row = cur.fetchone()
+        assert row[0] is not None


### PR DESCRIPTION
## Summary
- ensure Popen doesn't block by discarding server output
- handle invalid SQL in rewrite helpers instead of panicking
- add `pggetone` functional test in python
- add rust test exercising `pggetone` with subquery

## Testing
- `cargo test --quiet`
- `pytest -q`
