### PR TITLE
Add pggetone tests and error propagation

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -31,7 +31,7 @@ use datafusion::{
 
 use crate::replace::{regclass_udfs, replace_set_command_with_namespace};
 use crate::session::{execute_sql, ClientOpts};
-use crate::user_functions::{register_current_schema, register_scalar_array_to_string, register_scalar_format_type, register_scalar_pg_encoding_to_char, register_scalar_pg_get_expr, register_scalar_pg_get_partkeydef, register_scalar_pg_get_userbyid, register_scalar_pg_table_is_visible, register_scalar_pg_tablespace_location, register_scalar_regclass_oid};
+use crate::user_functions::{register_current_schema, register_pggetone, register_scalar_array_to_string, register_scalar_format_type, register_scalar_pg_encoding_to_char, register_scalar_pg_get_expr, register_scalar_pg_get_partkeydef, register_scalar_pg_get_userbyid, register_scalar_pg_table_is_visible, register_scalar_pg_tablespace_location, register_scalar_regclass_oid};
 use tokio::net::TcpStream;
 use tokio::io::AsyncReadExt;
 use tokio::io::AsyncWriteExt;
@@ -296,7 +296,8 @@ impl SimpleQueryHandler for DatafusionBackend {
         if results.is_empty() {
             // TODO: we are double parsing the sql here. this shouldn't be needed.
             // 
-            let query = replace_set_command_with_namespace(&query);        
+            let query = replace_set_command_with_namespace(&query)
+                .map_err(|e| PgWireError::ApiError(Box::new(e)))?;
             // zero-row result, but still need schema
             let df = self.ctx.sql(&query).await.map_err(|e| PgWireError::ApiError(Box::new(e)))?;
             let schema = df.schema();
@@ -577,6 +578,7 @@ pub async fn start_server(base_ctx: Arc<SessionContext>, addr: &str,
             register_scalar_pg_get_userbyid(&ctx)?;
             register_scalar_pg_encoding_to_char(&ctx)?;
             register_scalar_array_to_string(&ctx)?;
+            register_pggetone(&ctx)?;
             
             let df = ctx.sql("SELECT datname FROM pg_catalog.pg_database where datname='pgtry'").await?;
             if df.count().await? == 0 {

--- a/src/session.rs
+++ b/src/session.rs
@@ -142,13 +142,13 @@ pub async fn execute_sql(
     vec: Option<Vec<Option<Bytes>>>,
     vec0: Option<Vec<Type>>,
 ) -> datafusion::error::Result<(Vec<RecordBatch>, Arc<Schema>)> {
-    let sql = replace_set_command_with_namespace(&sql);
-    let sql = strip_default_collate(&sql);
-    let sql = rewrite_pg_custom_operator(&sql);
-    let sql = rewrite_schema_qualified_text(&sql);
-    let sql = replace_regclass(&sql);
-    let sql = rewrite_regtype_cast(&sql);
-    let (sql, aliases) = alias_all_columns(&sql);
+    let sql = replace_set_command_with_namespace(&sql)?;
+    let sql = strip_default_collate(&sql)?;
+    let sql = rewrite_pg_custom_operator(&sql)?;
+    let sql = rewrite_schema_qualified_text(&sql)?;
+    let sql = replace_regclass(&sql)?;
+    let sql = rewrite_regtype_cast(&sql)?;
+    let (sql, aliases) = alias_all_columns(&sql)?;
 
     
     let df = if let (Some(params), Some(types)) = (vec, vec0) {

--- a/test_col_types_query.py
+++ b/test_col_types_query.py
@@ -34,7 +34,7 @@ class TestPsycopgQueries(unittest.TestCase):
                 "127.0.0.1",
                 "--port",
                 str(port),
-            ], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            ], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
             conninfo = f"host=127.0.0.1 port={port} dbname=postgres password=pencil sslmode=disable"
             for _ in range(8):
                 try:

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -15,7 +15,7 @@ def server():
         "--default-schema", "public",
         "--host", "127.0.0.1",
         "--port", "5444",
-    ], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    ], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
     for _ in range(8):
         try:
@@ -57,3 +57,10 @@ def test_parameter_query(server):
         )
         row = cur.fetchone()
         assert row[0] >= 1
+
+def test_pggetone_subquery(server):
+    with psycopg.connect(CONN_STR) as conn:
+        cur = conn.cursor()
+        cur.execute("SELECT pggetone((select relname FROM pg_catalog.pg_class LIMIT 1))")
+        row = cur.fetchone()
+        assert row[0] is not None


### PR DESCRIPTION
## Summary
- make query rewriting helpers return errors on parse failure
- register `pggetone` UDF in server startup
- discard server output in tests to avoid blocking
- test `pggetone` with a subquery using parentheses

## Testing
- `cargo test --quiet`
- `pytest -q`