### PR TITLE
Add CI workflow for Python and Rust tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install Python dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run cargo tests
+        run: cargo test --all --verbose
+
+      - name: Run rust coverage
+        run: |
+          cargo install cargo-tarpaulin
+          cargo tarpaulin --out Xml --out Text --timeout 120
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: tarpaulin-report
+          path: cobertura.xml
+
+      - name: Run python tests
+        run: pytest -q


### PR DESCRIPTION
## Summary
- run Python and Cargo tests on pull requests
- report coverage using cargo-tarpaulin

## Testing
- `cargo test --all --quiet`
- `pytest -q`
