### PR TITLE
Add tests for map_pg_type

### DIFF
--- a/src/db_table.rs
+++ b/src/db_table.rs
@@ -193,3 +193,17 @@ pub fn print_execution_log(log:Arc<Mutex<Vec<ScanTrace>>>){
 
     println!("{}", serde_json::to_string_pretty(&out).unwrap());
 }
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_map_pg_type() {
+        assert_eq!(map_pg_type("int"), DataType::Int32);
+        assert_eq!(map_pg_type("integer"), DataType::Int32);
+        assert_eq!(map_pg_type("bigint"), DataType::Int64);
+        assert_eq!(map_pg_type("bool"), DataType::Boolean);
+        assert_eq!(map_pg_type("varchar(20)"), DataType::Utf8);
+        assert_eq!(map_pg_type("unknown"), DataType::Utf8);
+    }
+}


### PR DESCRIPTION
## Summary
- add unit test for `db_table::map_pg_type`

## Testing
- `cargo test -- --test-threads=1 --nocapture`
- `pytest tests/test_functional.py::test_query_returns_text -vv -s` *(fails: KeyboardInterrupt)*