### PR TITLE
Fix all cargo build warnings

### DIFF
--- a/src/clean_duplicate_columns.rs
+++ b/src/clean_duplicate_columns.rs
@@ -11,7 +11,7 @@ fn alias_projection(select: &mut Select, counter: &mut usize, alias_map: &mut Ha
     for item in &select.projection {
         match item {
             SelectItem::UnnamedExpr(expr) => match expr {
-                Expr::Cast { expr: inner_expr, data_type, .. } => match data_type {
+                Expr::Cast { expr: _inner_expr, data_type, .. } => match data_type {
                     DataType::Regclass => {
                         let alias = format!("alias_{}", *counter);
                         *counter += 1;

--- a/src/db_table.rs
+++ b/src/db_table.rs
@@ -34,6 +34,7 @@ pub fn map_pg_type(pg_type: &str) -> DataType {
     }
 }
 
+#[allow(dead_code)]
 trait SchemaAccess {
     fn schema(&self) -> SchemaRef;
 }
@@ -51,6 +52,7 @@ impl SchemaAccess for ScanTrace {
 
 
 
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct ScanTrace {
     table: String,
@@ -157,7 +159,8 @@ impl TableProvider for ObservableMemTable {
 
 }
 
-pub fn print_execution_log(log:Arc<Mutex<Vec<ScanTrace>>>){
+#[allow(dead_code)]
+pub fn print_execution_log(log:Arc<Mutex<Vec<ScanTrace>>>) {
     let out: Vec<_> = log.lock().unwrap().iter().map(|entry| {
         let columns: Vec<_> = match &entry.projection {
             Some(p) => p.iter().map(|i| entry.schema().field(*i).name().clone()).collect(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,10 +9,8 @@ mod scalar_to_cte;
 
 use std::env;
 use std::sync::Arc;
-use arrow::util::pretty;
-use datafusion::prelude::SessionContext;
 use crate::server::start_server;
-use crate::session::{get_base_session_context, execute_sql};
+use crate::session::get_base_session_context;
 
 async fn run() -> anyhow::Result<()> {
     let args: Vec<String> = env::args().collect();
@@ -50,7 +48,7 @@ async fn run() -> anyhow::Result<()> {
     let address = format!("{}:{}", host, port);
 
 
-    let (ctx, log) = get_base_session_context(schema_path, default_catalog.clone(), default_schema.clone()).await?;
+    let (ctx, _log) = get_base_session_context(schema_path, default_catalog.clone(), default_schema.clone()).await?;
     // let results = execute_sql(&ctx, sql.as_str()).await?;
     // pretty::print_batches(&results)?;
     // print_execution_log(log.clone());

--- a/src/scalar_to_cte.rs
+++ b/src/scalar_to_cte.rs
@@ -102,10 +102,12 @@ mod visitor {
     /// Read-only walker that records every scalar sub-query appearing
     /// *directly* inside the projection list.
     #[derive(Default, Debug)]
+    #[allow(dead_code)]
     pub struct ScalarFinder {
         pub scalars: Vec<Expr>,
     }
 
+    #[allow(dead_code)]
     impl ScalarFinder {
         pub fn find(stmt: &Statement) -> Self {
             let mut this = Self::default();
@@ -197,12 +199,14 @@ mod rewriter {
     use super::*;
 
     #[derive(Debug)]
+    #[allow(dead_code)]
     struct PendingRewrite<'a> {
         expr_slot : &'a mut Expr,   
         info      : CorrelatedInfo, 
     }
 
     #[derive(Debug)]
+    #[allow(dead_code)]
     struct CorrelatedInfo {
         cte_ident   : Ident,
         subquery    : Box<Query>,
@@ -266,6 +270,7 @@ mod rewriter {
 
 
     /// `t1.id = t2.id`  →  `(outer=id, inner=id)`
+    #[allow(dead_code)]
     #[derive(Debug, Clone)]
     struct EqPair {
         outer: Vec<Ident>,
@@ -388,6 +393,7 @@ mod rewriter {
             unreachable!("template changed")
         }
 
+        #[allow(dead_code)]
         fn make_cross_join(alias: &Ident) -> Join {
             // dummy base table so we can grab the Join node
             let tmp = super::parse_sql(&format!("SELECT * FROM x CROSS JOIN {alias}"))
@@ -691,8 +697,8 @@ mod rewriter {
             // ---------- 1st pass: collect what needs rewriting ----------
             let mut collected = Vec::<(usize, CorrelatedInfo)>::new();
             for (idx, item) in sel.projection.iter().enumerate() {
-                if let SelectItem::UnnamedExpr(e)
-                | SelectItem::ExprWithAlias { expr: e, .. } = item
+                if let SelectItem::UnnamedExpr(_e)
+                | SelectItem::ExprWithAlias { expr: _e, .. } = item
                 {
                     if let Some(info) = self.analyse_scalar(item, &outer_alias) {
                         collected.push((idx, info));

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,7 +1,6 @@
 use std::sync::{Arc};
 
 use async_trait::async_trait;
-use datafusion::prelude::SessionConfig;
 use futures::{stream};
 use futures::Stream;
 
@@ -343,7 +342,7 @@ impl SimpleQueryHandler for DatafusionBackend {
 
         let _ = self.register_current_database(client);
         let _ = self.register_session_user(client);
-        let (results, schema) = execute_sql(&self.ctx, query, None, None).await.map_err(|e| PgWireError::ApiError(Box::new(e)))?;
+        let (results, _schema) = execute_sql(&self.ctx, query, None, None).await.map_err(|e| PgWireError::ApiError(Box::new(e)))?;
 
         let mut responses = Vec::new();
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,26 +1,17 @@
 use arrow::array::{Int32Array, StringArray};
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 
-use datafusion::catalog::CatalogProvider;
-use datafusion::catalog::SchemaProvider;
-
 use datafusion::catalog::memory::{MemoryCatalogProvider, MemorySchemaProvider};
-use datafusion::datasource::{MemTable, TableProvider, TableType};
-use datafusion::datasource::provider::TableProviderFilterPushDown;
+use datafusion::catalog::SchemaProvider;
+use datafusion::datasource::MemTable;
 use datafusion::execution::context::SessionContext;
-use datafusion::logical_expr::Expr;
-use datafusion::physical_plan::ExecutionPlan;
-use datafusion::error::Result;
-use async_trait::async_trait;
 use arrow::record_batch::RecordBatch;
 
 use serde::Deserialize;
-use serde_json::json;
 use serde_yaml;
 
 use std::collections::{BTreeMap, HashMap};
 use std::fs;
-use std::ops::Deref;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 use pgwire::api::Type;
@@ -32,8 +23,6 @@ use bytes::Bytes;
 use datafusion::scalar::ScalarValue;
 use crate::user_functions::{register_scalar_format_type, register_scalar_pg_tablespace_location, register_scalar_regclass_oid};
 use datafusion::common::{config_err, config::ConfigEntry};
-use arrow::array::{Int64Array, BooleanArray,
-    ListBuilder, ArrayRef};
 use datafusion::common::config::{ConfigExtension, ExtensionOptions};
 use crate::db_table::{map_pg_type, ObservableMemTable, ScanTrace};
 

--- a/src/user_functions.rs
+++ b/src/user_functions.rs
@@ -12,7 +12,7 @@ use datafusion::prelude::*;
 use std::sync::Arc;
 use datafusion::execution::SessionState;
 use datafusion::logical_expr::{ColumnarValue, Volatility};
-use arrow::array::{as_string_array, Array, ArrayRef, StringBuilder, ListArray};
+use arrow::array::{Array, ArrayRef, StringBuilder};
 use datafusion::common::utils::SingleRowListArrayBuilder;
 use futures::executor::block_on;
 use tokio::task::block_in_place;
@@ -163,7 +163,7 @@ pub fn register_scalar_pg_tablespace_location(ctx: &SessionContext) -> Result<()
         ArrowDataType::Utf8,
         Volatility::Immutable,
         {
-            std::sync::Arc::new(move |args| {
+            std::sync::Arc::new(move |_args| {
                 Ok(ColumnarValue::Scalar(ScalarValue::Utf8(None)))
             })
         },
@@ -352,7 +352,7 @@ pub fn register_scalar_pg_get_partkeydef(ctx: &SessionContext) -> Result<()> {
         let arrays = ColumnarValue::values_to_arrays(args)?;
         let oids = as_int64_array(&arrays[0])?;
         let mut builder = StringBuilder::new();
-        for i in 0..oids.len() {
+        for _ in 0..oids.len() {
             builder.append_null();
         }
         Ok(ColumnarValue::Array(Arc::new(builder.finish()) as ArrayRef))
@@ -474,7 +474,6 @@ pub fn register_scalar_array_to_string(ctx: &SessionContext) -> Result<()> {
     use arrow::datatypes::{DataType, Field};
     use datafusion::logical_expr::{ColumnarValue, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature, TypeSignature, Volatility};
     use std::sync::Arc;
-    use arrow::datatypes::ArrowNativeType;
 
     fn build_list<O: OffsetSizeTrait>(
         arr: ArrayRef,
@@ -743,7 +742,7 @@ pub fn register_pg_get_array(ctx: &SessionContext) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::array::{Int64Array, StringArray};
+    use arrow::array::{Int64Array, StringArray, ListArray};
     use arrow::datatypes::{DataType, Field, Schema};
     use arrow::record_batch::RecordBatch;
     use datafusion::catalog::memory::{MemoryCatalogProvider, MemorySchemaProvider};


### PR DESCRIPTION
## Summary
- clean up unused imports
- silence warnings for unused variables and helper functions
- annotate unused code for tests

## Testing
- `cargo build`
- `cargo test`