### PR TITLE
Add SHOW datestyle support

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -33,9 +33,19 @@ use crate::db_table::{map_pg_type, ObservableMemTable, ScanTrace};
 use crate::replace_any_group_by::rewrite_group_by_for_any;
 
 
-#[derive(Default, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub struct ClientOpts {
     pub application_name: String,
+    pub datestyle: String,
+}
+
+impl Default for ClientOpts {
+    fn default() -> Self {
+        Self {
+            application_name: String::new(),
+            datestyle: "ISO, MDY".to_string(),
+        }
+    }
 }
 
 
@@ -57,6 +67,10 @@ impl ExtensionOptions for ClientOpts {
                 println!("value is set!!!");
                 Ok(())
             }
+            "datestyle" => {
+                self.datestyle = value.to_string();
+                Ok(())
+            }
             "extra_float_digits" => {
                 Ok(())
             }
@@ -65,12 +79,18 @@ impl ExtensionOptions for ClientOpts {
     }
 
     fn entries(&self) -> Vec<ConfigEntry> {
-        vec![ConfigEntry {
-            // key: format!("{}.application_name", Self::PREFIX),
-            key: "application_name".to_string(),
-            value: Some(self.application_name.clone()),
-            description: "",
-        }]
+        vec![
+            ConfigEntry {
+                key: "application_name".to_string(),
+                value: Some(self.application_name.clone()),
+                description: "",
+            },
+            ConfigEntry {
+                key: "datestyle".to_string(),
+                value: Some(self.datestyle.clone()),
+                description: "",
+            },
+        ]
     }
 
 }

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -93,3 +93,20 @@ def test_empty_result_schema(server):
         assert cur.description[0].name == "relname"
         # OID 25 is the TEXT type returned by our server for name columns
         assert cur.description[0].type_code == 25
+
+
+def test_set_and_show_application_name(server):
+    with psycopg.connect(CONN_STR) as conn:
+        cur = conn.cursor()
+        cur.execute("SET application_name = 'pytest'")
+        cur.execute("SHOW application_name")
+        row = cur.fetchone()
+        assert row == ("application_name", "pytest")
+
+
+def test_show_datestyle(server):
+    with psycopg.connect(CONN_STR) as conn:
+        cur = conn.cursor()
+        cur.execute("SHOW datestyle")
+        row = cur.fetchone()
+        assert row == ("datestyle", "ISO, MDY")


### PR DESCRIPTION
## Summary
- include `datestyle` in ClientOpts so `SHOW datestyle` works
- add tests for showing `datestyle` and setting/showing `application_name`

## Testing
- `cargo test --quiet`
- `pytest -q`