### PR TITLE
Add parse_schema_file tests

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -561,7 +561,7 @@ mod tests {
     use super::*;
     use tempfile::NamedTempFile;
     use std::io::Write;
-    use arrow::array::{Int32Array, StringArray};
+    use arrow::array::{Int32Array, Int64Array, StringArray};
     use arrow::datatypes::DataType;
     use arrow::array::{ArrayRef};
 
@@ -671,6 +671,55 @@ public:
         let inner = binding.as_any().downcast_ref::<StringArray>().unwrap();
         assert_eq!(inner.value(0), "x");
         assert_eq!(inner.value(1), "y");
+    }
+
+    #[test]
+    fn test_parse_schema_file_multiple_tables() {
+        let yaml = r#"
+mycatalog:
+  myschema:
+    t1:
+      type: table
+      schema:
+        id: int
+        name: varchar
+      rows:
+        - id: 1
+          name: Foo
+    t2:
+      type: table
+      schema:
+        val: bigint
+      rows:
+        - val: 10
+        - val: 20
+"#;
+
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        std::io::Write::write_all(&mut file, yaml.as_bytes()).unwrap();
+
+        let parsed = parse_schema_file(file.path().to_str().unwrap());
+        let schemas = parsed.get("mycatalog").unwrap();
+        let myschema = schemas.get("myschema").unwrap();
+
+        let (t1_schema, t1_batches) = myschema.get("t1").unwrap();
+        assert_eq!(t1_schema.fields()[0].name(), "id");
+        assert_eq!(t1_schema.fields()[0].data_type(), &DataType::Int32);
+        assert_eq!(t1_schema.fields()[1].name(), "name");
+        assert_eq!(t1_schema.fields()[1].data_type(), &DataType::Utf8);
+        let t1_batch = &t1_batches[0];
+        assert_eq!(t1_batch.num_rows(), 1);
+        assert_eq!(t1_batch.column(0).as_any().downcast_ref::<Int32Array>().unwrap().value(0), 1);
+        assert_eq!(t1_batch.column(1).as_any().downcast_ref::<StringArray>().unwrap().value(0), "Foo");
+
+        let (t2_schema, t2_batches) = myschema.get("t2").unwrap();
+        assert_eq!(t2_schema.fields()[0].name(), "val");
+        assert_eq!(t2_schema.fields()[0].data_type(), &DataType::Int64);
+        let t2_batch = &t2_batches[0];
+        assert_eq!(t2_batch.num_rows(), 2);
+        let arr = t2_batch.column(0).as_any().downcast_ref::<Int64Array>().unwrap();
+        assert_eq!(arr.value(0), 10);
+        assert_eq!(arr.value(1), 20);
     }
 
 

--- a/todo-tests.md
+++ b/todo-tests.md
@@ -3,7 +3,9 @@
 ~~1. **Test `db_table.map_pg_type`** – Verify that various Postgres type strings (e.g. `int`, `bigint`, `bool`, `varchar(20)`) map to the correct Arrow `DataType`. Include an unknown type to ensure the default mapping is `Utf8`.~~
    - done (tests added)
 2. **Test `session.rename_columns`** – Create a `RecordBatch` with a simple schema and ensure `rename_columns` correctly renames columns based on the provided mapping without altering data or order.
-3. **Test `session.parse_schema_file`** – Use a small YAML schema file to confirm that tables and schemas are loaded with the expected column types and row values.
+~~3. **Test `session.parse_schema_file`** – Use a small YAML schema file to confirm that tables and schemas are loaded with the expected column types and row values.~~
+  - done (tests added)
+  - additional tests for multiple tables added
 ~~4. **Test `server.arrow_to_pg_type`** – Check that Arrow `DataType` values map to the appropriate pgwire `Type` enums.~~
    - done (tests added)
 5. **Test `server.batch_to_field_info`** – Build a tiny `RecordBatch` and verify the generated `FieldInfo` array matches the batch schema and requested format.


### PR DESCRIPTION
## Summary
- expand parse_schema_file coverage with multiple tables
- note additional tests in todo list

## Testing
- `cargo test --quiet`
