### PR TITLE
Implement pg_tablespace_location alias and virtual columns

### DIFF
--- a/agents-dev/intellij-compat-tasks.md
+++ b/agents-dev/intellij-compat-tasks.md
@@ -50,6 +50,10 @@ When registering the existing pg_tablespace_location UDF, call .with_aliases(["p
 
 this can just return a dummy value.
 
+Done: Registered the UDF with the pg_catalog alias and returned an empty string
+as a placeholder. Added a regression test invoking the function via the schema-
+qualified name to ensure it resolves correctly.
+
 # Task 4 – reuse Task 1 for current_user inside pg_user query
 
 requires task 1

--- a/src/user_functions.rs
+++ b/src/user_functions.rs
@@ -157,8 +157,8 @@ pub fn register_scalar_regclass_oid(ctx: &SessionContext) -> Result<()> {
 }
 
 pub fn register_scalar_pg_tablespace_location(ctx: &SessionContext) -> Result<()> {
-    // TODO: this always returns empty string for now.
-    //   If there is a db supporting tablespaces, this should be done correctly.
+    // TODO: this always returns an empty string for now. If there is a
+    // database supporting tablespaces, this should return the actual location.
     let ctx_arc = Arc::new(ctx.clone());
 
     let udf = create_udf(
@@ -166,8 +166,11 @@ pub fn register_scalar_pg_tablespace_location(ctx: &SessionContext) -> Result<()
         vec![ArrowDataType::Utf8],
         ArrowDataType::Utf8,
         Volatility::Immutable,
-        { std::sync::Arc::new(move |args| Ok(ColumnarValue::Scalar(ScalarValue::Utf8(None)))) },
-    );
+        std::sync::Arc::new(move |_args| {
+            Ok(ColumnarValue::Scalar(ScalarValue::Utf8(Some(String::new()))))
+        }),
+    )
+    .with_aliases(["pg_catalog.pg_tablespace_location"]);
     ctx_arc.register_udf(udf);
     Ok(())
 }

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -126,6 +126,14 @@ def test_system_columns_hidden_from_star(server):
         assert "xmin" not in columns
 
 
+def test_pg_tablespace_location_function(server):
+    with psycopg.connect(CONN_STR) as conn:
+        cur = conn.cursor()
+        cur.execute("SELECT pg_catalog.pg_tablespace_location('1')")
+        row = cur.fetchone()
+        assert row[0] == ""
+
+
 def test_error_logging():
     proc = subprocess.Popen([
         "cargo", "run", "--quiet", "--",


### PR DESCRIPTION
## Summary
- add virtual system columns when building tables
- register `pg_tablespace_location` with a `pg_catalog` alias and return an empty string
- test the new function alias
- update expectations in session tests
- mark task 3 as done in the IntelliJ tasks doc

## Testing
- `cargo test`
- `pytest -q`