### PR TITLE
Fix pg_tablespace_location alias

### DIFF
--- a/agents-dev/intellij-compat-tasks.md
+++ b/agents-dev/intellij-compat-tasks.md
@@ -54,6 +54,9 @@ When registering the existing pg_tablespace_location UDF, call .with_aliases(["p
 
 this can just return a dummy value.
 
+Done: the registration now includes the schema-qualified alias and a test exercises
+`SELECT pg_catalog.pg_tablespace_location('pg_default')`, expecting a NULL result.
+
 # Task 4 – reuse Task 1 for current_user inside pg_user query
 
 requires task 1

--- a/src/user_functions.rs
+++ b/src/user_functions.rs
@@ -166,8 +166,9 @@ pub fn register_scalar_pg_tablespace_location(ctx: &SessionContext) -> Result<()
         vec![ArrowDataType::Utf8],
         ArrowDataType::Utf8,
         Volatility::Immutable,
-        { std::sync::Arc::new(move |args| Ok(ColumnarValue::Scalar(ScalarValue::Utf8(None)))) },
-    );
+        std::sync::Arc::new(move |_args| Ok(ColumnarValue::Scalar(ScalarValue::Utf8(None)))),
+    )
+    .with_aliases(["pg_catalog.pg_tablespace_location"]);
     ctx_arc.register_udf(udf);
     Ok(())
 }

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -142,6 +142,14 @@ def test_system_columns_hidden_from_star(server):
         assert "xmin" not in columns
 
 
+def test_pg_tablespace_location_alias(server):
+    with psycopg.connect(CONN_STR) as conn:
+        cur = conn.cursor()
+        cur.execute("SELECT pg_catalog.pg_tablespace_location('pg_default')")
+        row = cur.fetchone()
+        assert row == (None,)
+
+
 def test_error_logging():
     proc = subprocess.Popen([
         "cargo", "run", "--quiet", "--",


### PR DESCRIPTION
## Summary
- expose `pg_catalog.pg_tablespace_location` alias
- test pg_tablespace_location alias works
- mark task 3 as complete in docs

## Testing
- `cargo test`
- `pytest -q`
