### PR TITLE
Fix regoper cast and tests

### DIFF
--- a/agents-dev/intellij-compat-tasks.md
+++ b/agents-dev/intellij-compat-tasks.md
@@ -192,6 +192,8 @@ ERROR:  This feature is not implemented: Unsupported SQL type Custom(ObjectName(
 
 since we keep conexclop as _text and it's always null, we can shortcut this ::regoper::{whatevertype} for now. just return null.
 
+Done: Added `rewrite_regoper_cast` which replaces casts to `regoper` with `NULL` and integrated it into the SQL rewrite pipeline. Functional and unit tests cover `conexclop::regoper::text` and array forms to ensure they return `NULL` instead of failing.
+
 # Task 10 - ::oid type
 
 these queries crash

--- a/src/session.rs
+++ b/src/session.rs
@@ -21,7 +21,19 @@ use std::path::Path;
 use std::sync::{Arc, Mutex};
 use pgwire::api::Type;
 use crate::clean_duplicate_columns::alias_all_columns;
-use crate::replace::{regclass_udfs, replace_regclass, replace_set_command_with_namespace, rewrite_array_subquery, rewrite_brace_array_literal, rewrite_pg_custom_operator, rewrite_regtype_cast, rewrite_schema_qualified_custom_types, rewrite_schema_qualified_text, strip_default_collate};
+use crate::replace::{
+    regclass_udfs,
+    replace_regclass,
+    replace_set_command_with_namespace,
+    rewrite_array_subquery,
+    rewrite_brace_array_literal,
+    rewrite_pg_custom_operator,
+    rewrite_regtype_cast,
+    rewrite_regoper_cast,
+    rewrite_schema_qualified_custom_types,
+    rewrite_schema_qualified_text,
+    strip_default_collate,
+};
 use crate::scalar_to_cte::rewrite_subquery_as_cte;
 use bytes::Bytes;
 
@@ -196,6 +208,7 @@ pub fn print_params(params: &Vec<Option<Bytes>>) {
 pub fn rewrite_filters(sql: &str) -> datafusion::error::Result<(String, HashMap<String, String>)>{
     let sql = replace_set_command_with_namespace(&sql)?;
     let sql = strip_default_collate(&sql)?;
+    let sql = rewrite_regoper_cast(&sql)?;
     let sql = rewrite_array_subquery(&sql).unwrap();
     let sql = rewrite_brace_array_literal(&sql).unwrap();
     let sql = rewrite_pg_custom_operator(&sql)?;

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -152,6 +152,22 @@ def test_conexclop_unnest(server):
         assert row[0] is None
 
 
+def test_conexclop_regoper_cast(server):
+    with psycopg.connect(CONN_STR) as conn:
+        cur = conn.cursor()
+        cur.execute(
+            "select array(select unnest::regoper::varchar from unnest(C.conexclop)) from pg_catalog.pg_constraint C limit 1"
+        )
+        row = cur.fetchone()
+        assert row[0] is None
+
+        cur.execute(
+            "select conexclop::regoper::text from pg_catalog.pg_constraint limit 1"
+        )
+        row = cur.fetchone()
+        assert row[0] is None
+
+
 def test_pg_tablespace_location_alias(server):
     with psycopg.connect(CONN_STR) as conn:
         cur = conn.cursor()


### PR DESCRIPTION
## Summary
- implement `rewrite_regoper_cast` to handle regoper casts
- rewrite array rewrite logic and pipelines
- test regoper casts with new unit and integration tests
- document completed Task 9

## Testing
- `cargo test`
- `pytest -q`