### PR TITLE
Task 13: allow pg_get_expr to accept BIGINT

### DIFF
--- a/agents-dev/intellij-compat-tasks.md
+++ b/agents-dev/intellij-compat-tasks.md
@@ -277,6 +277,11 @@ Candidate functions:
 pg_catalog.pg_get_expr(Utf8, Int32)
 pg_catalog.pg_get_expr(Utf8, Int32, Boolean).
 
+Done: The pg_get_expr UDF now accepts BIGINT for the relation
+OID argument, matching casts produced by rewrite_oid_cast. A
+new integration test exercises `SELECT pg_catalog.pg_get_expr('hello', 1::oid)`
+and confirms the function succeeds.
+
 
 # Task 14 - other errors
 

--- a/src/user_functions.rs
+++ b/src/user_functions.rs
@@ -328,10 +328,10 @@ pub fn register_scalar_pg_get_expr(ctx: &SessionContext) -> Result<()> {
             Self {
                 sig: Signature::one_of(
                     vec![
-                        TypeSignature::Exact(vec![DataType::Utf8, DataType::Int32]),
+                        TypeSignature::Exact(vec![DataType::Utf8, DataType::Int64]),
                         TypeSignature::Exact(vec![
                             DataType::Utf8,
-                            DataType::Int32,
+                            DataType::Int64,
                             DataType::Boolean,
                         ]),
                     ],

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -184,6 +184,15 @@ def test_cast_column_oid(server):
         assert row[0] is None
 
 
+def test_pg_get_expr_int64(server):
+    """pg_get_expr should accept BIGINT arguments produced by ::oid casts."""
+    with psycopg.connect(CONN_STR) as conn:
+        cur = conn.cursor()
+        cur.execute("SELECT pg_catalog.pg_get_expr('hello', 1::oid)")
+        row = cur.fetchone()
+        assert row == ("hello",)
+
+
 
 
 def test_error_logging():


### PR DESCRIPTION
## Summary
- relax `pg_get_expr` signature to accept `BIGINT` OIDs
- add integration test exercising `pg_get_expr('hello', 1::oid)`
- mark task 13 as done in docs

## Testing
- `cargo test --quiet`
- `pytest -q`