### PR TITLE
Implement quote_ident and other viewdef utilities

### DIFF
--- a/agents-dev/intellij-compat-tasks.md
+++ b/agents-dev/intellij-compat-tasks.md
@@ -263,12 +263,16 @@ from pg_catalog.pg_constraint C
 
 # Task 12 - fix missing functions
 
-ERROR: Error during planning: Invalid function 'pg_catalog.quote_ident'.
-ERROR: Error during planning: Invalid function 'pg_get_expr'. <- only needs an alias probably
-ERROR: Error during planning: Invalid function 'pg_catalog.translate'.
-ERROR: Error during planning: Invalid function 'pg_catalog.pg_get_viewdef'.
-ERROR: Error during planning: Invalid function 'pg_catalog.pg_get_function_arguments'.
-ERROR:  Error during planning: Invalid function 'pg_catalog.pg_get_indexdef'.
+Implemented stubs for missing functions and registered them with the server:
+
+* `quote_ident` simply echoes its argument.
+* `translate` performs basic character substitution.
+* `pg_get_viewdef`, `pg_get_function_arguments` and `pg_get_indexdef` now return
+  NULL placeholders.
+* Added an alias for `pg_get_expr` so unqualified calls succeed.
+
+Integration tests exercise these functions and confirm they return expected
+placeholder values.
 
 # Task 13 - type coercion
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -34,7 +34,32 @@ use datafusion::{
 
 use crate::replace::{regclass_udfs};
 use crate::session::{execute_sql, ClientOpts};
-use crate::user_functions::{register_current_schema, register_pg_get_array, register_pg_get_one, register_pg_get_statisticsobjdef_columns, register_pg_postmaster_start_time, register_pg_relation_is_publishable, register_scalar_array_to_string, register_scalar_format_type, register_scalar_pg_age, register_scalar_pg_encoding_to_char, register_scalar_pg_get_expr, register_scalar_pg_get_partkeydef, register_scalar_pg_get_userbyid, register_scalar_pg_is_in_recovery, register_scalar_pg_table_is_visible, register_scalar_pg_tablespace_location, register_scalar_regclass_oid, register_scalar_txid_current, register_array_agg};
+use crate::user_functions::{
+    register_array_agg,
+    register_current_schema,
+    register_pg_get_array,
+    register_pg_get_function_arguments,
+    register_pg_get_indexdef,
+    register_pg_get_one,
+    register_pg_get_statisticsobjdef_columns,
+    register_pg_get_viewdef,
+    register_pg_postmaster_start_time,
+    register_pg_relation_is_publishable,
+    register_quote_ident,
+    register_scalar_array_to_string,
+    register_scalar_format_type,
+    register_scalar_pg_age,
+    register_scalar_pg_encoding_to_char,
+    register_scalar_pg_get_expr,
+    register_scalar_pg_get_partkeydef,
+    register_scalar_pg_get_userbyid,
+    register_scalar_pg_is_in_recovery,
+    register_scalar_pg_table_is_visible,
+    register_scalar_pg_tablespace_location,
+    register_scalar_regclass_oid,
+    register_scalar_txid_current,
+    register_translate,
+};
 use tokio::net::TcpStream;
 use tokio::io::AsyncReadExt;
 use tokio::io::AsyncWriteExt;
@@ -822,6 +847,11 @@ pub async fn start_server(base_ctx: Arc<SessionContext>, addr: &str,
             register_scalar_pg_age(&ctx)?;
             register_scalar_pg_is_in_recovery(&ctx)?;
             register_scalar_txid_current(&ctx)?;
+            register_quote_ident(&ctx)?;
+            register_translate(&ctx)?;
+            register_pg_get_viewdef(&ctx)?;
+            register_pg_get_function_arguments(&ctx)?;
+            register_pg_get_indexdef(&ctx)?;
 
             
             let df = ctx.sql("SELECT datname FROM pg_catalog.pg_database where datname='pgtry'").await?;

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -184,6 +184,34 @@ def test_cast_column_oid(server):
         assert row[0] is None
 
 
+def test_quote_ident_and_translate(server):
+    with psycopg.connect(CONN_STR) as conn:
+        cur = conn.cursor()
+        cur.execute("SELECT pg_catalog.quote_ident('tbl')")
+        row = cur.fetchone()
+        assert row == ('tbl',)
+
+        cur.execute("SELECT pg_catalog.translate('abc','a','b')")
+        row = cur.fetchone()
+        assert row == ('bbc',)
+
+
+def test_getdef_functions(server):
+    with psycopg.connect(CONN_STR) as conn:
+        cur = conn.cursor()
+        cur.execute("SELECT pg_catalog.pg_get_viewdef(1)")
+        row = cur.fetchone()
+        assert row == (None,)
+
+        cur.execute("SELECT pg_catalog.pg_get_function_arguments(1)")
+        row = cur.fetchone()
+        assert row == (None,)
+
+        cur.execute("SELECT pg_catalog.pg_get_indexdef(1)")
+        row = cur.fetchone()
+        assert row == (None,)
+
+
 
 
 def test_error_logging():


### PR DESCRIPTION
## Summary
- implement `quote_ident`, `translate`, `pg_get_viewdef`, `pg_get_function_arguments`, `pg_get_indexdef`
- expose alias for `pg_get_expr`
- register new helpers in server
- add integration tests
- mark task 12 complete in intellij-compat-tasks

## Testing
- `cargo test --quiet`
- `pytest -q`