### PR TITLE
Implement oid parameter support

### DIFF
--- a/agents-dev/intellij-compat-tasks.md
+++ b/agents-dev/intellij-compat-tasks.md
@@ -107,6 +107,10 @@ Extend replace_regtype_cast or add a new rewrite to normalise ::oid casts to ::i
 
 Update execute_sql_inner param decoding to accept Type::OID (code already handles INT2/4/8).
 
+Done: execute_sql_inner now converts OID parameters to BIGINT
+scalars so queries like `WHERE oid = $1::oid` work. A new integration
+test covers this case.
+
 # Task 6 – add array_agg shim
 Query (excerpt): select … array_agg(inhparent::bigint order by inhseqno)::varchar
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -258,6 +258,13 @@ pub async fn execute_sql_inner(
                     let v = i32::from_be_bytes(bytes[..].try_into().unwrap());
                     ScalarValue::Int32(Some(v))
                 }
+                (Some(bytes), Type::OID) => {
+                    // OID values are 32-bit unsigned integers. We map them to
+                    // BIGINT to align with `rewrite_oid_cast`, which rewrites
+                    // `::oid` casts on parameters to BIGINT.
+                    let v = u32::from_be_bytes(bytes[..].try_into().unwrap());
+                    ScalarValue::Int64(Some(v as i64))
+                }
                 (Some(bytes), Type::VARCHAR)
                 | (Some(bytes), Type::TEXT)
                 | (Some(bytes), Type::BPCHAR)
@@ -269,6 +276,7 @@ pub async fn execute_sql_inner(
                 (None, Type::INT2) => ScalarValue::Int16(None),
                 (None, Type::INT8) => ScalarValue::Int64(None),
                 (None, Type::INT4) => ScalarValue::Int32(None),
+                (None, Type::OID) => ScalarValue::Int64(None),
                 (None, Type::VARCHAR)
                 | (None, Type::TEXT)
                 | (None, Type::BPCHAR)

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -184,6 +184,18 @@ def test_cast_column_oid(server):
         assert row[0] is None
 
 
+def test_oid_parameter(server):
+    """Parameters typed as OID should be accepted and decoded."""
+    with psycopg.connect(CONN_STR) as conn:
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT nspname FROM pg_catalog.pg_namespace WHERE oid = %s::oid",
+            (11,),
+        )
+        row = cur.fetchone()
+        assert row == ("pg_catalog",)
+
+
 def test_quote_ident_and_translate(server):
     with psycopg.connect(CONN_STR) as conn:
         cur = conn.cursor()


### PR DESCRIPTION
## Summary
- support `Type::OID` parameters
- test using oid parameters
- mark Task 5 as done

## Testing
- `cargo test --quiet`
- `pytest -q`