### PR TITLE
Fix regoperator and regprocedure casts

### DIFF
--- a/agents-dev/completed-tasks.md
+++ b/agents-dev/completed-tasks.md
@@ -55,3 +55,48 @@ The failure was due to casts using the special type `"char"` which the
 parser returned as a custom type.  Added a rewrite step to map such casts
 to the regular `CHAR` type and updated the pipeline and tests.
 
+# Task 6:
+exec_error query: "select O.oid as id,
+       O.amopstrategy as strategy,
+       O.amopopr as op_id,
+       O.amopopr::regoperator::varchar as op_sig,
+       O.amopsortfamily /* null */ as sort_family_id,
+       SF.opfname /* null */ as sort_family,
+       O.amopfamily as family_id,
+       C.oid as class_id
+from pg_catalog.pg_amop O
+    left join pg_opfamily F on O.amopfamily = F.oid
+    left join pg_opfamily SF on O.amopsortfamily = SF.oid
+    left join pg_depend D on D.classid = 'pg_amop'::regclass and O.oid = D.objid and D.objsubid = 0
+    left join pg_opclass C on D.refclassid = 'pg_opclass'::regclass and C.oid = D.refobjid and D.refobjsubid = 0
+where C.opcnamespace = $1::oid or C.opcnamespace is null and F.opfnamespace = $2::oid
+  --  and pg_catalog.age(O.xmin) <= #TXAGE
+order by C.oid, F.oid"
+exec_error params: Some([Some(b"\0\0\0\0\0\0\x08\x98"), Some(b"\0\0\0\0\0\0\x08\x98")])
+exec_error error: NotImplemented("Unsupported SQL type Custom(ObjectName([Identifier(Ident { value: \"regoperator\", quote_style: None, span: Span(Location(1,80)..Location(1,91)) })]), [])")
+## # Task 6: Done
+Added `rewrite_regoperator_cast` which maps `regoperator` casts to `TEXT`.
+The filter rewrite pipeline now applies this transformation and tests verify it.
+
+# Task 7:
+exec_error query: "select P.oid as id,
+       P.amprocnum as num,
+       P.amproc::oid as proc_id,
+       P.amproc::regprocedure::varchar as proc_sig,
+       P.amproclefttype::regtype::varchar as left_type,
+       P.amprocrighttype::regtype::varchar as right_type,
+       P.amprocfamily as family_id,
+       C.oid as class_id
+from pg_catalog.pg_amproc P
+    left join pg_opfamily F on P.amprocfamily = F.oid
+    left join pg_depend D on D.classid = 'pg_amproc'::regclass and P.oid = D.objid and D.objsubid = 0
+    left join pg_opclass C on D.refclassid = 'pg_opclass'::regclass and C.oid = D.refobjid and D.refobjsubid = 0
+where C.opcnamespace = $1::oid or C.opcnamespace is null and F.opfnamespace = $2::oid
+  --  and pg_catalog.age(P.xmin) <= #TXAGE
+order by C.oid, F.oid"
+exec_error params: Some([Some(b"\0\0\0\0\0\0\x08\x98"), Some(b"\0\0\0\0\0\0\x08\x98")])
+exec_error error: NotImplemented("Unsupported SQL type Custom(ObjectName([Identifier(Ident { value: \"regprocedure\", quote_style: None, span: Span(Location(1,77)..Location(1,89)) })]), [])")
+## # Task 7: Done
+Implemented `rewrite_regprocedure_cast` to replace `regprocedure` casts with `TEXT`.
+Pipeline updated and dedicated tests ensure the rewrite works.
+

--- a/src/session.rs
+++ b/src/session.rs
@@ -29,7 +29,7 @@ use crate::replace::{
     rewrite_brace_array_literal,
     rewrite_pg_custom_operator,
     rewrite_regtype_cast, rewrite_oid_cast, rewrite_char_cast,
-    rewrite_regoper_cast,
+    rewrite_regoper_cast, rewrite_regoperator_cast, rewrite_regprocedure_cast,
     rewrite_available_updates,
     rewrite_schema_qualified_custom_types,
     rewrite_schema_qualified_text,
@@ -210,6 +210,8 @@ pub fn rewrite_filters(sql: &str) -> datafusion::error::Result<(String, HashMap<
     let sql = replace_set_command_with_namespace(&sql)?;
     let sql = strip_default_collate(&sql)?;
     let sql = rewrite_regoper_cast(&sql)?;
+    let sql = rewrite_regoperator_cast(&sql)?;
+    let sql = rewrite_regprocedure_cast(&sql)?;
     let sql = rewrite_available_updates(&sql)?;
     let sql = rewrite_array_subquery(&sql).unwrap();
     let sql = rewrite_brace_array_literal(&sql).unwrap();


### PR DESCRIPTION
## Summary
- support `regoperator` and `regprocedure` casts
- call new rewrites in the query preprocessing pipeline
- test rewrites for new casts
- document completion of tasks 6 and 7

## Testing
- `cargo test`
- `pytest -q`