### PR TITLE
Implement pg_get_function_* functions

### DIFF
--- a/agents-dev/completed-tasks.md
+++ b/agents-dev/completed-tasks.md
@@ -55,3 +55,9 @@ The failure was due to casts using the special type `"char"` which the
 parser returned as a custom type.  Added a rewrite step to map such casts
 to the regular `CHAR` type and updated the pipeline and tests.
 
+# Task 9: Done
+The parser rejected `pg_get_function_result` and `pg_get_function_sqlbody`
+functions. Implemented placeholder UDFs returning NULL for both and
+registered them with the server. Added functional tests verifying the
+new functions return `NULL`.
+

--- a/src/server.rs
+++ b/src/server.rs
@@ -39,6 +39,8 @@ use crate::user_functions::{
     register_current_schema,
     register_pg_get_array,
     register_pg_get_function_arguments,
+    register_pg_get_function_result,
+    register_pg_get_function_sqlbody,
     register_pg_get_indexdef,
     register_pg_get_one,
     register_pg_get_statisticsobjdef_columns,
@@ -851,6 +853,8 @@ pub async fn start_server(base_ctx: Arc<SessionContext>, addr: &str,
             register_translate(&ctx)?;
             register_pg_get_viewdef(&ctx)?;
             register_pg_get_function_arguments(&ctx)?;
+            register_pg_get_function_result(&ctx)?;
+            register_pg_get_function_sqlbody(&ctx)?;
             register_pg_get_indexdef(&ctx)?;
 
             

--- a/src/user_functions.rs
+++ b/src/user_functions.rs
@@ -1339,6 +1339,68 @@ pub fn register_pg_get_indexdef(ctx: &SessionContext) -> Result<()> {
     Ok(())
 }
 
+/// pg_catalog.pg_get_function_result(oid) → text
+pub fn register_pg_get_function_result(ctx: &SessionContext) -> Result<()> {
+    use arrow::array::{ArrayRef, StringBuilder};
+    use arrow::datatypes::DataType;
+    use datafusion::logical_expr::{create_udf, ColumnarValue, Volatility};
+    use std::sync::Arc;
+
+    let fun = |args: &[ColumnarValue]| -> Result<ColumnarValue> {
+        let len = match args.first() {
+            Some(ColumnarValue::Array(a)) => a.len(),
+            _ => 1,
+        };
+        let mut b = StringBuilder::with_capacity(len, len);
+        for _ in 0..len {
+            b.append_null();
+        }
+        Ok(ColumnarValue::Array(Arc::new(b.finish()) as ArrayRef))
+    };
+
+    let udf = create_udf(
+        "pg_catalog.pg_get_function_result",
+        vec![DataType::Int64],
+        DataType::Utf8,
+        Volatility::Stable,
+        Arc::new(fun),
+    )
+    .with_aliases(["pg_get_function_result"]);
+    ctx.register_udf(udf);
+    Ok(())
+}
+
+/// pg_catalog.pg_get_function_sqlbody(oid) → text
+pub fn register_pg_get_function_sqlbody(ctx: &SessionContext) -> Result<()> {
+    use arrow::array::{ArrayRef, StringBuilder};
+    use arrow::datatypes::DataType;
+    use datafusion::logical_expr::{create_udf, ColumnarValue, Volatility};
+    use std::sync::Arc;
+
+    let fun = |args: &[ColumnarValue]| -> Result<ColumnarValue> {
+        let len = match args.first() {
+            Some(ColumnarValue::Array(a)) => a.len(),
+            _ => 1,
+        };
+        let mut b = StringBuilder::with_capacity(len, len);
+        for _ in 0..len {
+            b.append_null();
+        }
+        Ok(ColumnarValue::Array(Arc::new(b.finish()) as ArrayRef))
+    };
+
+    let udf = create_udf(
+        "pg_catalog.pg_get_function_sqlbody",
+        vec![DataType::Int64],
+        DataType::Utf8,
+        Volatility::Stable,
+        Arc::new(fun),
+    )
+    .with_aliases(["pg_get_function_sqlbody"]);
+    ctx.register_udf(udf);
+    Ok(())
+}
+
 
 
 #[cfg(test)]

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -223,6 +223,14 @@ def test_getdef_functions(server):
         row = cur.fetchone()
         assert row == (None,)
 
+        cur.execute("SELECT pg_catalog.pg_get_function_result(1)")
+        row = cur.fetchone()
+        assert row == (None,)
+
+        cur.execute("SELECT pg_catalog.pg_get_function_sqlbody(1)")
+        row = cur.fetchone()
+        assert row == (None,)
+
 def test_pg_get_expr_int64(server):
     """pg_get_expr should accept BIGINT arguments produced by ::oid casts."""
     with psycopg.connect(CONN_STR) as conn:


### PR DESCRIPTION
## Summary
- add pg_get_function_result and pg_get_function_sqlbody user functions
- register them in the server
- test new functions
- mark intellij Task 9 as done

## Testing
- `cargo test --quiet`
- `pytest -q`