### PR TITLE
Implement pg_available_extension_versions

### DIFF
--- a/agents-dev/intellij-compat-tasks.md
+++ b/agents-dev/intellij-compat-tasks.md
@@ -209,3 +209,7 @@ Did you mean 'pg_catalog.pg_get_function_arguments'?")), Diagnostic(Diagnostic {
 exec_error query: "select E.oid        as id,\n       E.xmin       as state_number,\n       extname      as name,\n       extversion   as version,\n       extnamespace as schema_id,\n       nspname      as schema_name\n       ,\n       array(select unnest\n             from unnest(available_versions)\n             where unnest > extversion) as available_updates\n       \nfrom pg_catalog.pg_extension E\n       join pg_namespace N on E.extnamespace = N.oid\n       left join (select name, array_agg(version) as available_versions\n                  from pg_available_extension_versions()\n                  group by name) V on E.extname = V.name\n       \n--  where pg_catalog.age(E.xmin) <= #TXAGE"
 exec_error params: Some([])
 exec_error error: Plan("table function 'pg_available_extension_versions' not found")
+## # Task 10: Done
+Added a stub implementation for the `pg_available_extension_versions()`
+table function and registered it during server startup so IntelliJ queries can
+resolve successfully.

--- a/src/server.rs
+++ b/src/server.rs
@@ -43,6 +43,7 @@ use crate::user_functions::{
     register_pg_get_one,
     register_pg_get_statisticsobjdef_columns,
     register_pg_get_viewdef,
+    register_pg_available_extension_versions,
     register_pg_postmaster_start_time,
     register_pg_relation_is_publishable,
     register_quote_ident,
@@ -849,6 +850,7 @@ pub async fn start_server(base_ctx: Arc<SessionContext>, addr: &str,
             register_scalar_txid_current(&ctx)?;
             register_quote_ident(&ctx)?;
             register_translate(&ctx)?;
+            register_pg_available_extension_versions(&ctx)?;
             register_pg_get_viewdef(&ctx)?;
             register_pg_get_function_arguments(&ctx)?;
             register_pg_get_indexdef(&ctx)?;

--- a/src/user_functions.rs
+++ b/src/user_functions.rs
@@ -1339,6 +1339,94 @@ pub fn register_pg_get_indexdef(ctx: &SessionContext) -> Result<()> {
     Ok(())
 }
 
+/// pg_catalog.pg_available_extension_versions() -> TABLE
+///
+/// Returns information about available extension versions. For now this
+/// implementation returns an empty result set but exposes the expected
+/// columns so queries referencing the function succeed.
+pub fn register_pg_available_extension_versions(ctx: &SessionContext) -> Result<()> {
+    use arrow::datatypes::{DataType, Field, Schema};
+    use std::sync::Arc;
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("name", DataType::Utf8, true),
+        Field::new("version", DataType::Utf8, true),
+        Field::new("superuser", DataType::Boolean, true),
+        Field::new("trusted", DataType::Boolean, true),
+        Field::new("relocatable", DataType::Boolean, true),
+        Field::new("schema", DataType::Utf8, true),
+        Field::new(
+            "requires",
+            DataType::List(Arc::new(Field::new("item", DataType::Utf8, true))),
+            true,
+        ),
+        Field::new("comment", DataType::Utf8, true),
+    ]));
+
+    #[derive(Debug)]
+    struct TableFn {
+        schema: SchemaRef,
+    }
+
+    #[async_trait]
+    impl TableProvider for TableFn {
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+
+        fn schema(&self) -> SchemaRef {
+            self.schema.clone()
+        }
+
+        fn table_type(&self) -> TableType {
+            TableType::Base
+        }
+
+        async fn scan(
+            &self,
+            _session: &dyn Session,
+            projection: Option<&Vec<usize>>,
+            _filters: &[Expr],
+            _limit: Option<usize>,
+        ) -> Result<Arc<dyn datafusion::physical_plan::ExecutionPlan>> {
+            let batch = RecordBatch::new_empty(self.schema.clone());
+            Ok(MemorySourceConfig::try_new_exec(
+                &[vec![batch]],
+                self.schema.clone(),
+                projection.cloned(),
+            )?)
+        }
+    }
+
+    #[derive(Debug)]
+    struct Func {
+        schema: SchemaRef,
+    }
+
+    impl TableFunctionImpl for Func {
+        fn call(&self, exprs: &[Expr]) -> Result<Arc<dyn TableProvider>> {
+            if !exprs.is_empty() {
+                return plan_err!("pg_available_extension_versions takes no arguments");
+            }
+            Ok(Arc::new(TableFn {
+                schema: self.schema.clone(),
+            }))
+        }
+    }
+
+    ctx.register_udtf(
+        "pg_available_extension_versions",
+        Arc::new(Func {
+            schema: schema.clone(),
+        }),
+    );
+    ctx.register_udtf(
+        "pg_catalog.pg_available_extension_versions",
+        Arc::new(Func { schema }),
+    );
+    Ok(())
+}
+
 
 
 #[cfg(test)]
@@ -1658,6 +1746,19 @@ mod tests {
                          .unwrap().value(0);
     
         assert!(v2 == v1 + 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn available_extension_versions_empty() -> Result<()> {
+        let ctx = SessionContext::new();
+        register_pg_available_extension_versions(&ctx)?;
+        let batches = ctx
+            .sql("SELECT * FROM pg_available_extension_versions()")
+            .await?
+            .collect()
+            .await?;
+        assert_eq!(batches[0].num_rows(), 0);
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- add stub UDTF `pg_available_extension_versions`
- register new UDTF in server startup
- test new function returns an empty set
- mark Task 10 as done in the tasks list

## Testing
- `cargo test`
- `pytest -q`