### PR TITLE
Fix schema-qualified UDTF names

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -34,6 +34,7 @@ use crate::replace::{
     rewrite_available_updates,
     rewrite_schema_qualified_custom_types,
     rewrite_schema_qualified_text,
+    rewrite_schema_qualified_udtfs,
     strip_default_collate,
 };
 use crate::scalar_to_cte::rewrite_subquery_as_cte;
@@ -231,6 +232,7 @@ pub fn rewrite_filters(sql: &str) -> datafusion::error::Result<(String, HashMap<
     let sql = rewrite_pg_custom_operator(&sql)?;
     let sql = rewrite_schema_qualified_text(&sql)?;
     let sql = rewrite_schema_qualified_custom_types(&sql)?;
+    let sql = rewrite_schema_qualified_udtfs(&sql)?;
     let sql = rewrite_char_cast(&sql)?;
     let sql = replace_regclass(&sql)?;
     let sql = rewrite_regtype_cast(&sql)?;

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -248,6 +248,13 @@ def test_pg_get_expr_int64(server):
         assert row == ("hello",)
 
 
+def test_pg_get_keywords_schema(server):
+    with psycopg.connect(CONN_STR) as conn:
+        cur = conn.cursor()
+        cur.execute("SELECT * FROM pg_catalog.pg_get_keywords()")
+        assert cur.fetchall() == []
+
+
 
 
 


### PR DESCRIPTION
## Summary
- rewrite schema-qualified table function names
- support rewriting in session filter pipeline
- test pg_get_keywords schema-qualified call in rust and python

## Testing
- `cargo test --quiet`
- `pytest -q`