### PR TITLE
Implement current_schemas UDF

### DIFF
--- a/agents-dev/vscode-compat-tasks.md
+++ b/agents-dev/vscode-compat-tasks.md
@@ -11,6 +11,8 @@ postgres=# select * from current_schemas(true);
  {pg_catalog,public}
 (1 row)
 
+Resolved by adding a new `current_schemas` UDF returning `pg_catalog` and `public`.
+
 # Task 62:
 exec_error query: "DISCARD ALL"
 exec_error params: None

--- a/src/server.rs
+++ b/src/server.rs
@@ -37,6 +37,7 @@ use crate::session::{execute_sql, ClientOpts};
 use crate::user_functions::{
     register_array_agg,
     register_current_schema,
+    register_current_schemas,
     register_pg_get_array,
     register_oidvector_to_array,
     register_pg_get_function_arguments,
@@ -842,6 +843,7 @@ pub async fn start_server(base_ctx: Arc<SessionContext>, addr: &str,
             register_scalar_regclass_oid(&ctx)?;
             register_scalar_pg_tablespace_location(&ctx)?;
             register_current_schema(&ctx)?;
+            register_current_schemas(&ctx)?;
             register_scalar_format_type(&ctx)?;
             register_scalar_pg_get_expr(&ctx)?;
             register_scalar_pg_get_partkeydef(&ctx)?;

--- a/src/user_functions.rs
+++ b/src/user_functions.rs
@@ -460,6 +460,33 @@ pub fn register_current_schema(ctx: &SessionContext) -> Result<()> {
     Ok(())
 }
 
+pub fn register_current_schemas(ctx: &SessionContext) -> Result<()> {
+    use arrow::array::{ArrayRef, ListBuilder, StringBuilder};
+    use arrow::datatypes::{DataType, Field};
+    use datafusion::logical_expr::{create_udf, ColumnarValue, Volatility};
+    use std::sync::Arc;
+
+    let fun = |_args: &[ColumnarValue]| -> Result<ColumnarValue> {
+        let mut builder = ListBuilder::new(StringBuilder::new());
+        builder.values().append_value("pg_catalog");
+        builder.values().append_value("public");
+        builder.append(true);
+        Ok(ColumnarValue::Array(Arc::new(builder.finish()) as ArrayRef))
+    };
+
+    let list_dt = DataType::List(Arc::new(Field::new("item", DataType::Utf8, true)));
+    let udf = create_udf(
+        "current_schemas",
+        vec![DataType::Boolean],
+        list_dt.clone(),
+        Volatility::Stable,
+        Arc::new(fun),
+    )
+    .with_aliases(["pg_catalog.current_schemas"]);
+    ctx.register_udf(udf);
+    Ok(())
+}
+
 pub fn register_scalar_pg_table_is_visible(ctx: &SessionContext) -> Result<()> {
     use arrow::array::{ArrayRef, BooleanBuilder};
     use arrow::datatypes::DataType;
@@ -2327,6 +2354,28 @@ mod tests {
         let inner = list.value(0);
         let inner = inner.as_any().downcast_ref::<Int64Array>().unwrap();
         assert_eq!(inner.values(), &[1, 2, 3]);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn current_schemas_returns_defaults() -> Result<()> {
+        use arrow::array::{ListArray, StringArray};
+        let ctx = SessionContext::new();
+        register_current_schemas(&ctx)?;
+        let batches = ctx
+            .sql("SELECT current_schemas(true) AS v")
+            .await?
+            .collect()
+            .await?;
+        let list = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<ListArray>()
+            .unwrap();
+        let inner = list.value(0);
+        let inner = inner.as_any().downcast_ref::<StringArray>().unwrap();
+        assert_eq!(inner.value(0), "pg_catalog");
+        assert_eq!(inner.value(1), "public");
         Ok(())
     }
 

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -125,7 +125,15 @@ def test_current_user(server):
         cur = conn.cursor()
         cur.execute("SELECT current_database(), current_schema(), current_user")
         row = cur.fetchone()
-        assert row == ("pgtry", "public", "dbuser")
+    assert row == ("pgtry", "public", "dbuser")
+
+
+def test_current_schemas(server):
+    with psycopg.connect(CONN_STR) as conn:
+        cur = conn.cursor()
+        cur.execute("SELECT * FROM unnest(current_schemas(true))")
+        rows = cur.fetchall()
+        assert rows == [("pg_catalog",), ("public",)]
 
 
 def test_show_transaction_isolation_level(server):


### PR DESCRIPTION
## Summary
- implement current_schemas user-defined function
- register the function in the DataFusion server
- test behaviour in Rust and Python
- document completion of vscode task 61

## Testing
- `cargo test --quiet`
- `pytest -q`