### PR TITLE
Implement DISCARD ALL stub

### DIFF
--- a/agents-dev/completed-tasks.md
+++ b/agents-dev/completed-tasks.md
@@ -206,3 +206,6 @@ Unit tests verify the rewrite and casting now succeeds.
 # Task 45:
 exec_error query: "select T.tgrelid as table_id,\n       T.oid as trigger_id,\n       T.xmin as trigger_state_number,\n       T.tgname as trigger_name,\n       T.tgfoid as function_id,\n       pg_catalog.encode(T.tgargs, 'escape') as function_args,\n       T.tgtype as bits,\n       T.tgdeferrable as is_deferrable,\n       T.tginitdeferred as is_init_deferred,\n       T.tgenabled as trigger_fire_mode,\n       T.tgattr as columns,\n       T.tgconstraint != 0 as is_constraint,\n       T.tgoldtable /* null */ as old_table_name,\n       T.tgnewtable /* null */ as new_table_name,\n       pg_catalog.pg_get_triggerdef(T.oid, true) as source_code\nfrom pg_catalog.pg_trigger T\njoin pg_catalog.pg_class TAB on TAB.oid = T.tgrelid and TAB.relnamespace = $1::oid\nwhere true\n  --  and TAB.relname in ( :[*f_names] )\n  and pg_catalog.age(T.xmin) <= coalesce(nullif(greatest(pg_catalog.age($2::varchar::xid), -1), -1), 21
 
+
+## # Task 62: Done
+Implemented DISCARD ALL stub in the server. It returns the \"DISCARD ALL\" tag without running DataFusion.

--- a/agents-dev/vscode-compat-tasks.md
+++ b/agents-dev/vscode-compat-tasks.md
@@ -18,6 +18,10 @@ exec_error error: NotImplemented("Unsupported SQL statement: DISCARD ALL")
 
 just put a stub as discard all
 
+## Task 62: Done
+Implemented a stub handler for `DISCARD ALL` in the pgwire server.
+The command now returns the `DISCARD ALL` tag without error.
+
 # Task 63:
 
 exec_error query: "SELECT\n    db.oid as oid, \n    db.datname as name, \n    ta.spcname as spcname, \n    db.datallowconn,\n    db.datlastsysoid,\n    has_database_privilege(db.oid, 'CREATE') as cancreate, \n    datdba as owner, \n    db.datistemplate , \n    has_database_privilege(db.datname, 'connect') as canconnect,\n    datistemplate as is_system\n\nFROM\n    pg_database db\n    LEFT OUTER JOIN pg_tablespace ta ON db.dattablespace = ta.oid\n\nORDER BY datname;"

--- a/src/server.rs
+++ b/src/server.rs
@@ -484,6 +484,8 @@ impl SimpleQueryHandler for DatafusionBackend {
             return Ok(vec![Response::Execution(Tag::new("COMMIT"))]);
         } else if lowercase.starts_with("rollback") {
             return Ok(vec![Response::Execution(Tag::new("ROLLBACK"))]);
+        } else if lowercase == "discard all" {
+            return Ok(vec![Response::Execution(Tag::new("DISCARD ALL"))]);
         } else if lowercase == "show transaction isolation level" {
             let field_infos = Arc::new(vec![FieldInfo::new(
                 "transaction_isolation".to_string(),
@@ -567,6 +569,8 @@ impl ExtendedQueryHandler for DatafusionBackend {
 
         if sql_trim.is_empty() {
             return Ok(Response::Execution(Tag::new("")));
+        } else if lowercase == "discard all" {
+            return Ok(Response::Execution(Tag::new("DISCARD ALL")));
         } else if lowercase == "show transaction isolation level" {
             let field_infos = Arc::new(vec![FieldInfo::new(
                 "transaction_isolation".to_string(),
@@ -621,6 +625,8 @@ impl ExtendedQueryHandler for DatafusionBackend {
 
         if sql_trim.is_empty() {
             return Ok(DescribeStatementResponse::new(vec![], vec![]));
+        } else if lowercase == "discard all" {
+            return Ok(DescribeStatementResponse::new(vec![], vec![]));
         } else if lowercase == "show transaction isolation level" {
             let fields = vec![FieldInfo::new(
                 "transaction_isolation".to_string(),
@@ -664,6 +670,8 @@ impl ExtendedQueryHandler for DatafusionBackend {
         let lowercase = sql_trim.to_lowercase();
 
         if sql_trim.is_empty() {
+            return Ok(DescribePortalResponse::new(vec![]));
+        } else if lowercase == "discard all" {
             return Ok(DescribePortalResponse::new(vec![]));
         } else if lowercase == "show transaction isolation level" {
             let fields = vec![FieldInfo::new(

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -135,6 +135,13 @@ def test_show_transaction_isolation_level(server):
         row = cur.fetchone()
         assert row == ("read committed",)
 
+
+def test_discard_all(server):
+    with psycopg.connect(CONN_STR) as conn:
+        cur = conn.cursor()
+        cur.execute("DISCARD ALL")
+        assert cur.statusmessage == "DISCARD ALL"
+
 def test_system_columns_virtual(server):
     with psycopg.connect(CONN_STR) as conn:
         cur = conn.cursor()


### PR DESCRIPTION
## Summary
- support DISCARD ALL command in pgwire server
- handle DISCARD ALL for extended/simple query and describe paths
- test DISCARD ALL handling in functional tests
- mark vscode compatibility task 62 as done

## Testing
- `cargo test --quiet`
- `pytest -q`