### PR TITLE
Update reported PostgreSQL version

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -69,11 +69,15 @@ use crate::user_functions::{
     register_scalar_txid_current,
     register_encode,
     register_upper,
+    register_version_fn,
     register_translate,
 };
 use tokio::net::TcpStream;
 use tokio::io::AsyncReadExt;
 use tokio::io::AsyncWriteExt;
+
+/// PostgreSQL version reported to clients during startup and via `SHOW server_version`.
+pub const SERVER_VERSION: &str = "17.4.0";
 
 pub struct DatafusionBackend {
     ctx: Arc<SessionContext>,
@@ -136,6 +140,11 @@ mod tests {
         assert_eq!(arrow_to_pg_type(&DataType::LargeUtf8), Type::TEXT);
         assert_eq!(arrow_to_pg_type(&DataType::Float32), Type::FLOAT4);
         assert_eq!(arrow_to_pg_type(&DataType::Float64), Type::FLOAT8);
+    }
+
+    #[test]
+    fn test_server_version_constant() {
+        assert_eq!(SERVER_VERSION, "17.4.0");
     }
 }
 
@@ -715,7 +724,7 @@ impl PgWireServerHandlers for DatafusionBackendFactory {
 
     fn startup_handler(&self) -> Arc<Self::StartupHandler> {
         let mut params = DefaultServerParameterProvider::default();
-        params.server_version = "14.13".to_string();
+        params.server_version = SERVER_VERSION.to_string();
         println!("startup handler");
         Arc::new(Md5PasswordAuthStartupHandler::new(
             Arc::new(DummyAuthSource),
@@ -874,6 +883,7 @@ pub async fn start_server(base_ctx: Arc<SessionContext>, addr: &str,
             register_pg_get_ruledef(&ctx)?;
             register_encode(&ctx)?;
             register_upper(&ctx)?;
+            register_version_fn(&ctx)?;
 
             
             let df = ctx.sql("SELECT datname FROM pg_catalog.pg_database where datname='pgtry'").await?;

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -210,7 +210,15 @@ def test_name_cast_literal(server):
         cur = conn.cursor()
         cur.execute("SELECT '_RETURN'::name")
         row = cur.fetchone()
-        assert row == ("_RETURN",)
+    assert row == ("_RETURN",)
+
+
+def test_server_version_function(server):
+    with psycopg.connect(CONN_STR) as conn:
+        cur = conn.cursor()
+        cur.execute("SELECT version()")
+        row = cur.fetchone()
+        assert "17.4.0" in row[0]
 
 
 def test_quote_ident_and_translate(server):


### PR DESCRIPTION
## Summary
- expose a `SERVER_VERSION` constant and use it during startup
- register a custom `version()` UDF returning the same version string
- add rust unit test for the constant
- add python integration test for `version()`

## Testing
- `cargo test --quiet`
- `pytest -q`