### PR TITLE
Handle trailing semicolons for DISCARD ALL

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -484,7 +484,7 @@ impl SimpleQueryHandler for DatafusionBackend {
             return Ok(vec![Response::Execution(Tag::new("COMMIT"))]);
         } else if lowercase.starts_with("rollback") {
             return Ok(vec![Response::Execution(Tag::new("ROLLBACK"))]);
-        } else if lowercase == "discard all" {
+        } else if lowercase.starts_with("discard all") {
             return Ok(vec![Response::Execution(Tag::new("DISCARD ALL"))]);
         } else if lowercase == "show transaction isolation level" {
             let field_infos = Arc::new(vec![FieldInfo::new(
@@ -569,7 +569,7 @@ impl ExtendedQueryHandler for DatafusionBackend {
 
         if sql_trim.is_empty() {
             return Ok(Response::Execution(Tag::new("")));
-        } else if lowercase == "discard all" {
+        } else if lowercase.starts_with("discard all") {
             return Ok(Response::Execution(Tag::new("DISCARD ALL")));
         } else if lowercase == "show transaction isolation level" {
             let field_infos = Arc::new(vec![FieldInfo::new(
@@ -625,7 +625,7 @@ impl ExtendedQueryHandler for DatafusionBackend {
 
         if sql_trim.is_empty() {
             return Ok(DescribeStatementResponse::new(vec![], vec![]));
-        } else if lowercase == "discard all" {
+        } else if lowercase.starts_with("discard all") {
             return Ok(DescribeStatementResponse::new(vec![], vec![]));
         } else if lowercase == "show transaction isolation level" {
             let fields = vec![FieldInfo::new(
@@ -671,7 +671,7 @@ impl ExtendedQueryHandler for DatafusionBackend {
 
         if sql_trim.is_empty() {
             return Ok(DescribePortalResponse::new(vec![]));
-        } else if lowercase == "discard all" {
+        } else if lowercase.starts_with("discard all") {
             return Ok(DescribePortalResponse::new(vec![]));
         } else if lowercase == "show transaction isolation level" {
             let fields = vec![FieldInfo::new(

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -142,6 +142,13 @@ def test_discard_all(server):
         cur.execute("DISCARD ALL")
         assert cur.statusmessage == "DISCARD ALL"
 
+def test_discard_all_semicolon(server):
+    """DISCARD ALL with a trailing semicolon should be accepted."""
+    with psycopg.connect(CONN_STR) as conn:
+        cur = conn.cursor()
+        cur.execute("DISCARD ALL;")
+        assert cur.statusmessage == "DISCARD ALL"
+
 def test_system_columns_virtual(server):
     with psycopg.connect(CONN_STR) as conn:
         cur = conn.cursor()


### PR DESCRIPTION
## Summary
- allow `DISCARD ALL;` in simple and extended query handlers
- test DISCARD ALL with semicolon

## Testing
- `pytest -q`