### PR TITLE
Fix duplicate join predicate in scalar rewrites

### DIFF
--- a/agents-dev/intellij-compat-tasks.md
+++ b/agents-dev/intellij-compat-tasks.md
@@ -154,3 +154,11 @@ def test_rewrite_multiple_correlated_aliases(server):
 ```
 
 so it probably adds when there are multiple subqueries
+
+### Done
+
+`collect_paths` ignored bare identifiers so `tgrelid = rel.oid` was mistaken for
+an outer-only predicate and copied twice into the JOIN clause. The function now
+records identifier nodes, preventing the duplicate condition. A new Rust unit
+test checks the rewritten JOIN and a functional Python test runs the original
+query successfully.

--- a/src/scalar_to_cte.rs
+++ b/src/scalar_to_cte.rs
@@ -244,6 +244,7 @@ mod rewriter {
     fn collect_paths(e: &Expr, out: &mut Vec<Vec<Ident>>) {
         match e {
             Expr::CompoundIdentifier(p) => out.push(p.clone()),
+            Expr::Identifier(id) => out.push(vec![id.clone()]),
             Expr::BinaryOp { left, right, .. } => {
                 collect_paths(left, out);
                 collect_paths(right, out);
@@ -1449,6 +1450,20 @@ mod tests {
         assert!(s.contains("cls.oid = __cte1.adrelid"), "cls predicate not in JOIN");
         assert!(s.contains("attr.attnum = __cte1.adnum"), "attr predicate not in JOIN");
         assert!(!s.contains("WHERE adrelid = cls.oid"), "predicate left in CTE");
+
+        Ok(())
+    }
+
+    #[test]
+    fn trigger_count_subqueries() -> Result<()> {
+        let sql = "SELECT  rel.oid, (SELECT count(*) FROM pg_trigger WHERE tgrelid=rel.oid AND tgisinternal = FALSE) AS triggercount, (SELECT count(*) FROM pg_trigger WHERE tgrelid=rel.oid AND tgisinternal = FALSE AND tgenabled = 'O') AS has_enable_triggers FROM pg_class rel";
+        let out = rewrite(sql)?;
+        let s = out.sql.to_lowercase();
+        println!("rewritten: {}", s);
+
+        assert!(s.contains("rel.oid = __cte1.tgrelid"));
+        assert!(s.contains("rel.oid = __cte2.tgrelid"));
+        assert!(!s.contains("tgrelid = rel.oid"), "duplicate predicate present");
 
         Ok(())
     }

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -446,6 +446,28 @@ def test_rewrite_multiple_correlated_aliases(server):
         cur.fetchone()
 
 
+def test_trigger_count_subqueries(server):
+    sql = (
+        "SELECT  rel.oid,"
+        "        (SELECT count(*) FROM pg_catalog.pg_trigger WHERE tgrelid=rel.oid AND tgisinternal = FALSE) AS triggercount,"
+        "        (SELECT count(*) FROM pg_catalog.pg_trigger WHERE tgrelid=rel.oid AND tgisinternal = FALSE AND tgenabled = 'O') AS has_enable_triggers,"
+        "        (CASE WHEN rel.relkind = 'p' THEN true ELSE false END) AS is_partitioned,"
+        "        nsp.nspname AS schema,"
+        "        nsp.oid AS schemaoid,"
+        "        rel.relname AS name,"
+        "        CASE WHEN nsp.nspname like 'pg_%' or nsp.nspname = 'information_schema' THEN true ELSE false END as is_system "
+        "FROM    pg_catalog.pg_class rel "
+        "INNER JOIN pg_catalog.pg_namespace nsp ON rel.relnamespace= nsp.oid "
+        "WHERE rel.relkind IN ('r','t','f','p') "
+        "AND NOT rel.relispartition "
+        "ORDER BY nsp.nspname, rel.relname"
+    )
+    with psycopg.connect(CONN_STR) as conn:
+        cur = conn.cursor()
+        cur.execute(sql)
+        cur.fetchall()
+
+
 
 
 


### PR DESCRIPTION
## Summary
- fix detection of unqualified columns when analysing correlated predicates
- add regression test for trigger count query
- add functional test exercising the query
- document the solution in task list

## Testing
- `cargo test`
- `pytest -q`