### PR TITLE
Fix duplicated ON predicates

### DIFF
--- a/agents-dev/intellij-compat-tasks.md
+++ b/agents-dev/intellij-compat-tasks.md
@@ -154,3 +154,11 @@ def test_rewrite_multiple_correlated_aliases(server):
 ```
 
 so it probably adds when there are multiple subqueries
+
+### Done
+
+Duplicate join predicates were introduced because outer-only filters still
+contained the correlated comparisons. The rewriter now removes any outer-only
+predicate that matches a lifted correlation before constructing the JOIN. A
+Rust test verifies the join condition only lists each comparison once and the
+Python functional tests run the problematic query successfully.


### PR DESCRIPTION
## Summary
- avoid re-adding correlated filters as outer-only predicates
- add regression test for trigger count query
- add functional test for rewriting trigger counts
- document completion of task 83

## Testing
- `cargo test --quiet`
- `pytest -q`