### PR TITLE
Implement binary catalog compilation CLI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ bytes = "1.10.1"
 log = "0.4.27"
 once_cell = "1.21.3"
 datafusion-functions-aggregate = "47.0.0"
+clap = { version = "4.5.4", features = ["derive"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -55,6 +55,22 @@ Or use DBeaver/psql to introspect the schema.
 
 ---
 
+## Command Line Usage
+
+The project provides a small CLI with two subcommands:
+
+```bash
+# Compile YAML schemas into a binary catalog
+cargo run --quiet -- compile pg_catalog_data/pg_schema catalog.bin
+
+# Serve the pgwire interface using the compiled catalog
+cargo run --quiet -- serve pg_catalog_data/pg_schema --binary-file catalog.bin
+```
+
+If `--binary-file` is omitted, the server loads the YAML files directly.
+
+---
+
 ## Integration
 
 - Works with the [`pgwire`](https://github.com/sunng87/pgwire) crate for wire protocol emulation

--- a/agents-dev/refactor-to-binary.md
+++ b/agents-dev/refactor-to-binary.md
@@ -33,3 +33,6 @@ representation that the server can load very quickly.
 5. Extend functional tests to run the server with `--binary-file` to ensure the
    pgwire behaviour is unchanged.
 6. Document usage of the new commands in `README.md`.
+
+---
+Implemented Task 200: added binary catalog compiler and loader using Arrow IPC. Added clap-based CLI with serve and compile commands, unit tests for round trip, functional test running server with --binary-file, and documented CLI usage.

--- a/src/binary.rs
+++ b/src/binary.rs
@@ -1,0 +1,93 @@
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::{Read, Write, Cursor};
+use std::path::Path;
+
+use arrow::datatypes::SchemaRef;
+use arrow::record_batch::RecordBatch;
+use arrow::ipc::writer::StreamWriter;
+use arrow::ipc::reader::StreamReader;
+
+pub type CatalogData = HashMap<String, HashMap<String, HashMap<String, (SchemaRef, Vec<RecordBatch>)>>>;
+
+const MAGIC: &[u8] = b"PGCAT\0\1";
+
+pub fn write_binary(path: &Path, catalogs: &CatalogData) -> anyhow::Result<()> {
+    let mut file = File::create(path)?;
+    file.write_all(MAGIC)?;
+    let mut count: u32 = 0;
+    for schemas in catalogs.values() {
+        for tables in schemas.values() {
+            count += tables.len() as u32;
+        }
+    }
+    file.write_all(&count.to_le_bytes())?;
+    for (catalog, schemas) in catalogs {
+        for (schema, tables) in schemas {
+            for (table, (schema_ref, batches)) in tables {
+                file.write_all(&[catalog.len() as u8])?;
+                file.write_all(catalog.as_bytes())?;
+                file.write_all(&[schema.len() as u8])?;
+                file.write_all(schema.as_bytes())?;
+                file.write_all(&[table.len() as u8])?;
+                file.write_all(table.as_bytes())?;
+
+                let mut buf = Vec::new();
+                {
+                    let mut writer = StreamWriter::try_new(&mut buf, schema_ref)?;
+                    for batch in batches {
+                        writer.write(batch)?;
+                    }
+                    writer.finish()?;
+                }
+                file.write_all(&(buf.len() as u64).to_le_bytes())?;
+                file.write_all(&buf)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+pub fn read_binary(path: &Path) -> anyhow::Result<CatalogData> {
+    let mut file = File::open(path)?;
+    let mut header = vec![0u8; MAGIC.len()];
+    file.read_exact(&mut header)?;
+    if header != MAGIC {
+        anyhow::bail!("invalid magic header");
+    }
+    let mut count_buf = [0u8; 4];
+    file.read_exact(&mut count_buf)?;
+    let count = u32::from_le_bytes(count_buf);
+    let mut catalogs: CatalogData = HashMap::new();
+    for _ in 0..count {
+        let catalog = read_string(&mut file)?;
+        let schema = read_string(&mut file)?;
+        let table = read_string(&mut file)?;
+        let mut len_buf = [0u8;8];
+        file.read_exact(&mut len_buf)?;
+        let len = u64::from_le_bytes(len_buf) as usize;
+        let mut buf = vec![0u8; len];
+        file.read_exact(&mut buf)?;
+        let mut reader = StreamReader::try_new(Cursor::new(buf), None)?;
+        let schema_ref = reader.schema();
+        let mut batches = Vec::new();
+        for batch in reader {
+            batches.push(batch?);
+        }
+        catalogs
+            .entry(catalog)
+            .or_insert_with(HashMap::new)
+            .entry(schema)
+            .or_insert_with(HashMap::new)
+            .insert(table, (schema_ref, batches));
+    }
+    Ok(catalogs)
+}
+
+fn read_string<R: Read>(mut r: R) -> anyhow::Result<String> {
+    let mut len = [0u8;1];
+    r.read_exact(&mut len)?;
+    let mut buf = vec![0u8; len[0] as usize];
+    r.read_exact(&mut buf)?;
+    Ok(String::from_utf8(buf)?)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,66 +12,71 @@ mod logical_plan_rules;
 mod scalar_to_cte;
 mod replace_any_group_by;
 
-use std::env;
+use clap::{Parser, Subcommand};
 use std::sync::Arc;
 // use arrow::util::pretty;
 use crate::server::start_server;
-use crate::session::{get_base_session_context};
+use crate::session::{get_base_session_context, get_base_session_context_from_binary, parse_schema};
+
+#[derive(Parser)]
+#[command(name = "pg_catalog_rs")]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    Serve {
+        schema_dir: String,
+        #[arg(long)]
+        default_catalog: Option<String>,
+        #[arg(long)]
+        default_schema: Option<String>,
+        #[arg(long)]
+        host: Option<String>,
+        #[arg(long)]
+        port: Option<String>,
+        #[arg(long)]
+        capture: Option<String>,
+        #[arg(long)]
+        binary_file: Option<String>,
+    },
+    Compile {
+        yaml_dir: String,
+        binary_file: String,
+    },
+}
 
 async fn run() -> anyhow::Result<()> {
-    let args: Vec<String> = env::args().collect();
-    if args.len() < 3 {
-        println!("Usage: {} schema_directory --default-catalog public --default-schema postgres", args[0]);
-        std::process::exit(1);
+    let cli = Cli::parse();
+    match cli.command {
+        Commands::Serve { schema_dir, default_catalog, default_schema, host, port, capture, binary_file } => {
+            let default_catalog = default_catalog.unwrap_or_else(|| "datafusion".to_string());
+            let default_schema = default_schema.unwrap_or_else(|| "public".to_string());
+            let host = host.unwrap_or_else(|| "127.0.0.1".to_string());
+            let port = port.unwrap_or_else(|| "5433".to_string());
+            let address = format!("{}:{}", host, port);
+
+            let (ctx, _log) = if let Some(bin) = binary_file {
+                get_base_session_context_from_binary(&bin, default_catalog.clone(), default_schema.clone()).await?
+            } else {
+                get_base_session_context(&schema_dir, default_catalog.clone(), default_schema.clone()).await?
+            };
+
+            start_server(
+                Arc::new(ctx),
+                &address,
+                &default_catalog,
+                &default_schema,
+                capture.map(|p| p.into()),
+            ).await?;
+        }
+        Commands::Compile { yaml_dir, binary_file } => {
+            let schemas = parse_schema(&yaml_dir);
+            crate::binary::write_binary(std::path::Path::new(&binary_file), &schemas)?;
+        }
     }
-
-    let schema_path = &args[1];
-
-    let default_catalog = args.iter()
-        .position(|x| x == "--default-catalog")
-        .and_then(|i| args.get(i + 1))
-        .unwrap_or(&"datafusion".to_string())
-        .clone();
-
-    let default_schema = args.iter()
-        .position(|x| x == "--default-schema")
-        .and_then(|i| args.get(i + 1))
-        .unwrap_or(&"public".to_string())
-        .clone();
-
-    let host = args.iter()
-        .position(|x| x == "--host")
-        .and_then(|i| args.get(i + 1))
-        .unwrap_or(&"127.0.0.1".to_string())
-        .clone();
-
-    let port = args.iter()
-        .position(|x| x == "--port")
-        .and_then(|i| args.get(i + 1))
-        .unwrap_or(&"5433".to_string())
-        .clone();
-
-    let address = format!("{}:{}", host, port);
-
-    let capture_file = args.iter()
-        .position(|x| x == "--capture")
-        .and_then(|i| args.get(i + 1))
-        .cloned();
-
-
-    let (ctx, log) = get_base_session_context(schema_path, default_catalog.clone(), default_schema.clone()).await?;
-    // let results = execute_sql(&ctx, sql.as_str()).await?;
-    // pretty::print_batches(&results)?;
-    // print_execution_log(log.clone());
-    
-    start_server(
-        Arc::new(ctx),
-        &address,
-        &default_catalog,
-        &default_schema,
-        capture_file.map(|p| p.into()),
-    )
-    .await?;
 
     Ok(())
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -19,6 +19,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
+use crate::binary;
 use pgwire::api::Type;
 use crate::clean_duplicate_columns::alias_all_columns;
 use crate::replace::{
@@ -377,7 +378,7 @@ pub async fn execute_sql(
 }
 
 
-fn parse_schema(schema_path: &str) -> HashMap<String, HashMap<String, HashMap<String, (SchemaRef, Vec<RecordBatch>)>>> {
+pub fn parse_schema(schema_path: &str) -> HashMap<String, HashMap<String, HashMap<String, (SchemaRef, Vec<RecordBatch>)>>> {
     if Path::new(schema_path).is_file() {
         parse_schema_file(schema_path)
     } else if Path::new(schema_path).is_dir() {
@@ -615,10 +616,12 @@ fn build_table(def: TableDef) -> (SchemaRef, Vec<RecordBatch>) {
     (Arc::new(Schema::new(fields)), record_batches)
 }
 
-pub async fn get_base_session_context(schema_path: &String, default_catalog:String, default_schema:String) -> datafusion::error::Result<(SessionContext, Arc<Mutex<Vec<ScanTrace>>>)> {
+async fn build_session_context(
+    schemas: HashMap<String, HashMap<String, HashMap<String, (SchemaRef, Vec<RecordBatch>)>>>,
+    default_catalog:String,
+    default_schema:String,
+) -> datafusion::error::Result<(SessionContext, Arc<Mutex<Vec<ScanTrace>>>)> {
     let log: Arc<Mutex<Vec<ScanTrace>>> = Arc::new(Mutex::new(Vec::new()));
-
-    let schemas = parse_schema(schema_path.as_str());
 
     let mut config = datafusion::execution::context::SessionConfig::new()
         .with_default_catalog_and_schema(&default_catalog, &default_schema)
@@ -709,6 +712,16 @@ pub async fn get_base_session_context(schema_path: &String, default_catalog:Stri
 
 
     Ok((ctx, log))
+}
+
+pub async fn get_base_session_context(schema_path: &String, default_catalog:String, default_schema:String) -> datafusion::error::Result<(SessionContext, Arc<Mutex<Vec<ScanTrace>>>)> {
+    let schemas = parse_schema(schema_path.as_str());
+    build_session_context(schemas, default_catalog, default_schema).await
+}
+
+pub async fn get_base_session_context_from_binary(binary_path: &String, default_catalog:String, default_schema:String) -> datafusion::error::Result<(SessionContext, Arc<Mutex<Vec<ScanTrace>>>)> {
+    let schemas = crate::binary::read_binary(Path::new(binary_path))?;
+    build_session_context(schemas, default_catalog, default_schema).await
 }
 
 #[cfg(test)]
@@ -893,6 +906,32 @@ public:
         assert_eq!(out_schema.fields().len(), 1);
         assert_eq!(out_schema.field(0).name(), "xmin");
         assert_eq!(out[0].num_columns(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_binary_roundtrip() {
+        let yaml = r#"public:
+  myschema:
+    t:
+      type: table
+      schema:
+        id: int
+      rows:
+        - id: 1
+        - id: 2
+"#;
+
+        let dir = tempfile::tempdir().unwrap();
+        let yaml_path = dir.path().join("schema.yaml");
+        std::fs::write(&yaml_path, yaml).unwrap();
+        let parsed = parse_schema(yaml_path.to_str().unwrap());
+        let bin_path = dir.path().join("out.bin");
+        crate::binary::write_binary(&bin_path, &parsed).unwrap();
+        let parsed2 = crate::binary::read_binary(&bin_path).unwrap();
+        assert!(parsed2["public"]["myschema"].contains_key("t"));
+
+        let ctx_res = get_base_session_context_from_binary(&bin_path.to_str().unwrap().to_string(), "pgtry".to_string(), "public".to_string()).await;
+        assert!(ctx_res.is_ok());
     }
 }
 

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -9,6 +9,8 @@ import pytest
 
 CONN_STR = "host=127.0.0.1 port=5444 dbname=pgtry user=dbuser password=pencil sslmode=disable"
 
+BIN_CONN_STR = "host=127.0.0.1 port=5447 dbname=pgtry user=dbuser password=pencil sslmode=disable"
+
 @pytest.fixture(scope="module")
 def server():
     proc = subprocess.Popen([
@@ -37,8 +39,54 @@ def server():
     except subprocess.TimeoutExpired:
         proc.kill()
 
+
+@pytest.fixture(scope="module")
+def server_binary(tmp_path_factory):
+    bin_path = tmp_path_factory.mktemp("bin") / "catalog.bin"
+    subprocess.check_call([
+        "cargo", "run", "--quiet", "--",
+        "compile",
+        "pg_catalog_data/pg_schema",
+        str(bin_path),
+    ])
+
+    proc = subprocess.Popen([
+        "cargo", "run", "--quiet", "--",
+        "serve",
+        "pg_catalog_data/pg_schema",
+        "--default-catalog", "pgtry",
+        "--default-schema", "public",
+        "--host", "127.0.0.1",
+        "--port", "5447",
+        "--binary-file", str(bin_path),
+    ], text=True)
+
+    for _ in range(12):
+        try:
+            with psycopg.connect(BIN_CONN_STR):
+                break
+        except Exception:
+            time.sleep(5)
+    else:
+        proc.terminate()
+        raise RuntimeError("server failed to start")
+
+    yield proc
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+
 def test_query_returns_text(server):
     with psycopg.connect(CONN_STR) as conn:
+        cur = conn.cursor()
+        cur.execute("SELECT relname FROM pg_catalog.pg_class LIMIT 1")
+        row = cur.fetchone()
+        assert isinstance(row[0], str)
+
+def test_binary_server(server_binary):
+    with psycopg.connect(BIN_CONN_STR) as conn:
         cur = conn.cursor()
         cur.execute("SELECT relname FROM pg_catalog.pg_class LIMIT 1")
         row = cur.fetchone()


### PR DESCRIPTION
## Summary
- implement compile/serve CLI using clap
- add binary serialization for catalog data
- allow session context to load from binary file
- document CLI usage
- test binary roundtrip and server startup with binary catalog

## Testing
- `cargo test` *(fails: could not download dependencies)*
- `pytest -q` *(fails: server failed to start because cargo can't download dependencies)*