### PR TITLE
Fix subquery table qualification

### DIFF
--- a/agents-dev/vscode-compat-tasks.md
+++ b/agents-dev/vscode-compat-tasks.md
@@ -133,4 +133,4 @@ ORDER BY attnum;
 ```
 
 ### Done 92
-Implemented handling for `SHOW` commands when `information_schema` is disabled by intercepting the commands in `server.rs` and returning values from `ClientOpts`. Added a regression test ensuring scalar subqueries inside `CASE` expressions are rewritten correctly. All tests pass.
+Unqualified tables inside scalar subqueries were left without schema after rewriting which caused planning errors. Updated `alias_subquery_tables` to prefix tables with `pg_catalog` and added `qualify_unqualified_inner_table` test to verify. All tests pass.

--- a/src/replace.rs
+++ b/src/replace.rs
@@ -1435,7 +1435,10 @@ pub fn alias_subquery_tables(sql: &str) -> Result<String> {
     }
 
     fn alias_table_factor(tf: &mut TableFactor, counter: &mut usize) {
-        if let TableFactor::Table { alias, .. } = tf {
+        if let TableFactor::Table { name, alias, .. } = tf {
+            if name.0.len() == 1 {
+                name.0.insert(0, ObjectNamePart::Identifier(Ident::new("pg_catalog")));
+            }
             if alias.is_none() {
                 *alias = Some(TableAlias {
                     name: Ident::new(format!("subq{}_t", counter)),
@@ -1855,7 +1858,7 @@ mod tests {
     fn test_alias_subquery_tables() -> Result<(), Box<dyn std::error::Error>> {
         let sql = "SELECT (SELECT count(*) FROM pg_trigger WHERE tgrelid = rel.oid) FROM pg_class rel";
         let out = alias_subquery_tables(sql)?;
-        assert!(out.contains("FROM pg_trigger AS subq0_t"));
+        assert!(out.contains("FROM pg_catalog.pg_trigger AS subq0_t"));
         Ok(())
     }
 

--- a/src/scalar_to_cte.rs
+++ b/src/scalar_to_cte.rs
@@ -51,6 +51,7 @@
 use sqlparser::ast::*;
 use sqlparser::dialect::GenericDialect;
 use sqlparser::parser::Parser;
+use sqlparser::ast::ObjectNamePart;
 
 use datafusion::error::{DataFusionError, Result};
 use std::collections::HashSet;
@@ -673,6 +674,37 @@ mod rewriter {
             Ident::new(format!("__cte{}", self.cte_counter))
         }
 
+        fn qualify_pg_catalog_tables(query: &mut Query) {
+            fn qualify_factor(tf: &mut TableFactor) {
+                match tf {
+                    TableFactor::Table { name, .. } => {
+                        if name.0.len() == 1 {
+                            name.0.insert(0, ObjectNamePart::Identifier(Ident::new("pg_catalog")));
+                        }
+                    }
+                    TableFactor::Derived { subquery, .. } => {
+                        ScalarToCte::qualify_pg_catalog_tables(subquery);
+                    }
+                    TableFactor::NestedJoin { table_with_joins, .. } => {
+                        qualify_factor(&mut table_with_joins.relation);
+                        for j in &mut table_with_joins.joins {
+                            qualify_factor(&mut j.relation);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+
+            if let SetExpr::Select(sel) = query.body.as_mut() {
+                for twj in &mut sel.from {
+                    qualify_factor(&mut twj.relation);
+                    for j in &mut twj.joins {
+                        qualify_factor(&mut j.relation);
+                    }
+                }
+            }
+        }
+
         fn blank_with() -> With {
             let stmt = super::parse_sql("WITH x AS (SELECT 1) SELECT 1").unwrap();
             match stmt {
@@ -825,10 +857,13 @@ mod rewriter {
                     self.inject_group_by(inner_sel);
 
             }
-        
+
+            // prefix unqualified tables inside the CTE with pg_catalog
+            Self::qualify_pg_catalog_tables(&mut subq);
+
             // ★ use *subq* we just cleaned, not the original
             w.cte_tables
-                .push(Self::make_cte(&info.cte_ident, Box::new(subq)));  
+                .push(Self::make_cte(&info.cte_ident, Box::new(subq)));
         }
 
         fn add_join(&mut self, sel: &mut Select, info: &CorrelatedInfo) {
@@ -1617,6 +1652,15 @@ mod tests {
         assert!(lowered.contains("attr.attnum = __cte1.adnum"), "attr predicate missing");
         assert!(lowered.contains("case when atthasdef then __cte1.col"), "scalar not replaced inside case");
 
+        Ok(())
+    }
+
+    #[test]
+    fn qualify_unqualified_inner_table() -> Result<()> {
+        let sql = "SELECT (SELECT pg_attrdef.adbin FROM pg_attrdef WHERE adrelid = cls.oid AND adnum = attr.attnum) FROM pg_attribute AS attr JOIN pg_class AS cls ON cls.oid = attr.attrelid";
+        let out = rewrite(sql)?;
+        let lowered = out.sql.to_lowercase();
+        assert!(lowered.contains("from pg_catalog.pg_attrdef"), "inner table not qualified");
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- prefix unqualified tables when aliasing subqueries
- qualify tables inside scalar subquery CTEs
- add regression test for unqualified inner tables
- document fix for task 92

## Testing
- `cargo test --quiet`
- `pytest -q`


<!-- greptile_comment -->

## Greptile Summary

Implements improved table qualification handling in scalar subqueries and aliasing, ensuring proper `pg_catalog` schema prefixing for PostgreSQL compatibility.

- Enhanced `alias_table_factor` in `src/replace.rs` to automatically prefix unqualified tables with `pg_catalog` schema
- Added table qualification support in scalar subqueries via `src/scalar_to_cte.rs` for better system table compatibility
- Fixed issue #92 where unqualified tables in scalar subquery CTEs were causing planning errors
- Added regression test `qualify_unqualified_inner_table` to verify table qualification behavior



<!-- /greptile_comment -->