### PR TITLE
Add regression test for EXISTS case

### DIFF
--- a/agents-dev/inf-schema-tasks-192.md
+++ b/agents-dev/inf-schema-tasks-192.md
@@ -132,3 +132,6 @@ WHERE
 ORDER BY attnum;
 ```
 
+
+## Done
+Added a test for this query to ensure the scalar subquery in the CASE statement is rewritten into a CTE even when other EXISTS subqueries are present. The existing rewrite logic already produces the expected result.

--- a/src/scalar_to_cte.rs
+++ b/src/scalar_to_cte.rs
@@ -1620,5 +1620,65 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn case_when_exists_scalar_subquery() -> Result<()> {
+        let sql = r#"
+            SELECT
+              attname AS name,
+              attnum AS oid,
+              typ.oid AS typoid,
+              typ.typname AS datatype,
+              attnotnull AS not_null,
+              attr.atthasdef AS has_default_val,
+              nspname,
+              relname,
+              attrelid,
+              CASE
+                WHEN typ.typtype = 'd' THEN typ.typtypmod
+                ELSE atttypmod
+              END AS typmod,
+              CASE
+                WHEN atthasdef THEN (SELECT pg_get_expr(adbin, cls.oid) FROM pg_attrdef WHERE adrelid = cls.oid AND adnum = attr.attnum)
+                ELSE NULL
+              END AS default,
+              TRUE AS is_updatable,
+              CASE WHEN EXISTS (
+                SELECT *
+                FROM information_schema.key_column_usage
+                WHERE table_schema = nspname
+                  AND table_name = relname
+                  AND column_name = attname
+              ) THEN TRUE ELSE FALSE END AS isprimarykey,
+              CASE WHEN EXISTS (
+                SELECT *
+                FROM information_schema.table_constraints
+                WHERE table_schema = nspname
+                  AND table_name = relname
+                  AND constraint_type = 'UNIQUE'
+                  AND constraint_name IN (
+                    SELECT constraint_name
+                    FROM information_schema.constraint_column_usage
+                    WHERE table_schema = nspname
+                      AND table_name = relname
+                      AND column_name = attname
+                  )
+              ) THEN TRUE ELSE FALSE END AS isunique
+            FROM pg_attribute AS attr
+            JOIN pg_type AS typ ON attr.atttypid = typ.oid
+            JOIN pg_class AS cls ON cls.oid = attr.attrelid
+        "#;
+
+        let out = rewrite(sql)?;
+        let lowered = out.sql.to_lowercase();
+
+        assert!(lowered.starts_with("with __cte1"), "cte not injected");
+        assert!(lowered.contains("left outer join __cte1"), "join missing");
+        assert!(lowered.contains("cls.oid = __cte1.adrelid"), "cls predicate missing");
+        assert!(lowered.contains("attr.attnum = __cte1.adnum"), "attr predicate missing");
+        assert!(lowered.contains("case when atthasdef then __cte1.col"), "scalar not replaced inside case");
+
+        Ok(())
+    }
+
 
 }


### PR DESCRIPTION
## Summary
- add test coverage for complex scalar subquery with additional EXISTS
- document completion of task 92

## Testing
- `cargo test --quiet`
- `pytest -q`