### PR TITLE
Fix text array output quoting

### DIFF
--- a/pg_catalog_data/pg_schema/pg_catalog__pg_database.yaml
+++ b/pg_catalog_data/pg_schema/pg_catalog__pg_database.yaml
@@ -76,7 +76,9 @@ public:
         datlocale: null
         daticurules: null
         datcollversion: null
-        datacl: '[''=c/abadur'', ''abadur=CTc/abadur'']'
+        datacl:
+          - "=c/abadur"
+          - "abadur=CTc/abadur"
       - oid: 4
         datname: template0
         datdba: 10
@@ -94,4 +96,6 @@ public:
         datlocale: null
         daticurules: null
         datcollversion: null
-        datacl: '[''=c/abadur'', ''abadur=CTc/abadur'']'
+        datacl:
+          - "=c/abadur"
+          - "abadur=CTc/abadur"

--- a/schema.py
+++ b/schema.py
@@ -44,6 +44,8 @@ def safe_value(value):
         return value
     if isinstance(value, str):
         return value
+    if isinstance(value, list):
+        return [safe_value(v) for v in value]
     if isinstance(value, (datetime.datetime, datetime.date)):
         return value.isoformat()
     return str(value)

--- a/src/server.rs
+++ b/src/server.rs
@@ -586,20 +586,20 @@ fn batch_to_row_stream(batch: &RecordBatch, schema: Arc<Vec<FieldInfo>>) -> impl
 
                 DataType::List(inner) if inner.data_type() == &DataType::Utf8 => {
                     let list = col.as_any().downcast_ref::<ListArray>().unwrap();
-                    let value = if list.is_null(row_idx) {
-                        None::<String>
+                    let value: Option<Vec<String>> = if list.is_null(row_idx) {
+                        None
                     } else {
                         let arr = list.value(row_idx);
-                        let sa  = arr.as_any().downcast_ref::<StringArray>().unwrap();
+                        let sa = arr.as_any().downcast_ref::<StringArray>().unwrap();
                         let mut items = Vec::with_capacity(sa.len());
                         for i in 0..sa.len() {
                             if sa.is_null(i) {
                                 items.push("NULL".to_string());
                             } else {
-                                items.push(sa.value(i).replace('"', r#"\""#));
+                                items.push(sa.value(i).to_string());
                             }
                         }
-                        Some(format!("{{{}}}", items.join(",")))
+                        Some(items)
                     };
                     encoder.encode_field(&value).unwrap();
                 }

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -51,6 +51,24 @@ def test_query_returns_int(server):
         row = cur.fetchone()
         assert isinstance(row[0], int)
 
+
+def test_text_array_return(server):
+    """Arrays of text should be decoded as Python lists."""
+    with psycopg.connect(CONN_STR) as conn:
+        cur = conn.cursor()
+
+        cur.execute(
+            "SELECT datacl FROM pg_catalog.pg_database WHERE datname = 'postgres'"
+        )
+        row = cur.fetchone()
+        assert row == (None,)
+
+        cur.execute(
+            "SELECT datacl FROM pg_catalog.pg_database WHERE datname = 'template1'"
+        )
+        row = cur.fetchone()
+        assert row[0] == ["=c/abadur", "abadur=CTc/abadur"]
+
 def test_parameter_query(server):
     with psycopg.connect(CONN_STR) as conn:
         cur = conn.cursor()


### PR DESCRIPTION
## Summary
- handle list values correctly when generating schema YAML
- correct text array encoding via pgwire
- clean up pg_database datacl entries
- test datacl decoding from pgwire

## Testing
- `cargo test --no-run`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d74b740e4832f851e6f51c585a9b9

<!-- greptile_comment -->

## Greptile Summary

Fixes PostgreSQL array handling and text encoding across multiple components, improving compatibility with the pgwire protocol and cleaning up schema representation.

- Modified array output in `src/server.rs` to properly handle text array encoding without extra quote escaping
- Updated `schema.py` to correctly process list values when generating schema YAML
- Reformatted `pg_catalog_data/pg_schema/pg_catalog__pg_database.yaml` to use proper YAML list structure for `datacl` fields
- Added test coverage in `tests/test_functional.py` for array decoding of `datacl` fields



<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling and decoding of text arrays, ensuring proper representation of array fields as lists instead of formatted strings.
- **Tests**
  - Added a new test to verify correct decoding of text arrays from the database, confirming expected behavior for different database entries.
- **Chores**
  - Updated data representation in configuration files to use proper YAML list formatting for array fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->