### PR TITLE
Fix pg_database insert for array columns

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -1140,7 +1140,7 @@ pub async fn start_server(
                     726,
                     1,
                     1663,
-                    '{=Tc/dbuser,dbuser=CTc/dbuser}'
+                    ARRAY['=Tc/dbuser', 'dbuser=CTc/dbuser']
                 );
                 ").await?;
                 df.show().await?;

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -69,6 +69,12 @@ def test_text_array_return(server):
         row = cur.fetchone()
         assert row[0] == ["=c/abadur", "abadur=CTc/abadur"]
 
+        cur.execute(
+            "SELECT datacl FROM pg_catalog.pg_database WHERE datname = 'pgtry'"
+        )
+        row = cur.fetchone()
+        assert row[0] == ["=Tc/dbuser", "dbuser=CTc/dbuser"]
+
 def test_parameter_query(server):
     with psycopg.connect(CONN_STR) as conn:
         cur = conn.cursor()


### PR DESCRIPTION
## Summary
- fix array literal syntax when inserting into `pg_catalog.pg_database`
- verify datacl array for `pgtry` via functional test

## Testing
- `cargo test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683d853651f0832f8ac2509dc56cda36

<!-- greptile_comment -->

## Greptile Summary

Improves array handling in PostgreSQL catalog operations by fixing array literal syntax for the pg_database table's datacl column, ensuring compatibility with DataFusion's array type system.

- Modified array literal syntax in `src/server.rs` from PostgreSQL-style to explicit ARRAY constructor for better DataFusion compatibility
- Added test verification in `tests/test_functional.py` for datacl array handling in pg_database table
- Ensures proper access control list (ACL) representation for database users



<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the format of the database access control list to use an array of strings for improved compatibility.
- **Tests**
  - Expanded test coverage to verify correct handling and decoding of database access control lists as arrays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->