### PR TITLE
Fix SHOW command handling

### DIFF
--- a/notes.md
+++ b/notes.md
@@ -34,3 +34,6 @@ PostgreSQL                                      DataFusion
 └────────────────────────────────┘
 
 ```
+## SHOW command fix
+- Added proper SQL parsing for SHOW commands using sqlparser to handle trailing semicolons.
+- SHOW now returns a single column with the variable value, matching PostgreSQL output.

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -125,7 +125,11 @@ def test_set_and_show_application_name(server):
         cur.execute("SET application_name = 'pytest'")
         cur.execute("SHOW application_name")
         row = cur.fetchone()
-        assert row == ("application_name", "pytest")
+        assert row == ("pytest",)
+
+        cur.execute("SHOW application_name;")
+        row = cur.fetchone()
+        assert row == ("pytest",)
 
 
 def test_show_datestyle(server):
@@ -133,7 +137,7 @@ def test_show_datestyle(server):
         cur = conn.cursor()
         cur.execute("SHOW datestyle")
         row = cur.fetchone()
-        assert row == ("datestyle", "ISO, MDY")
+        assert row == ("ISO, MDY",)
 
 
 def test_show_search_path(server):
@@ -141,7 +145,7 @@ def test_show_search_path(server):
         cur = conn.cursor()
         cur.execute("SHOW search_path")
         row = cur.fetchone()
-        assert row == ("search_path", '"$user", public')
+        assert row == ('"$user", public',)
 
 
 def test_current_user(server):


### PR DESCRIPTION
## Summary
- parse SHOW commands with `sqlparser`
- return single-column output for SHOW variables
- test trailing semicolon and new output format
- document the SHOW command update

## Testing
- `cargo test --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68400c989728832f9c7862de7efabca7

<!-- greptile_comment -->

## Greptile Summary

Enhances SHOW command handling to better match PostgreSQL's behavior by implementing proper SQL parsing and single-column output format.

- Modified `src/server.rs` to use sqlparser for robust SHOW command parsing and handle trailing semicolons
- Updated response format in wire protocol to return single-column output matching PostgreSQL's format
- Added test cases in `tests/test_functional.py` to verify semicolon handling and output format
- Documented SHOW command improvements in `notes.md` with relation to PostgreSQL compatibility



<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of SQL SHOW commands to correctly parse queries with trailing semicolons and align output with PostgreSQL by returning only the variable value in results.

- **Documentation**
  - Updated documentation to describe the improved SHOW command handling and output format.

- **Tests**
  - Updated functional tests for SHOW commands to expect the new single-column output format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->