### PR TITLE
Support nullable columns in register_table

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -69,7 +69,10 @@ async fn run() -> anyhow::Result<()> {
         "crm",
         "crm",
         "users",
-        vec![("id", DataType::Int32), ("name", DataType::Utf8)],
+        vec![
+            ("id", DataType::Int32, false),
+            ("name", DataType::Utf8, true),
+        ],
     )?;
     
     start_server(


### PR DESCRIPTION
## Summary
- allow setting column nullability in `register_table`
- update call sites and add nullability checks in tests

## Testing
- `cargo test --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842d90d1578832f834a9a83b4c376d5

<!-- greptile_comment -->

## Greptile Summary

Enhanced the `register_table` functionality in pg_catalog to support explicit column nullability control, improving PostgreSQL schema compatibility.

- Added nullability parameter to column definitions in `src/register_table.rs`
- Updated `src/main.rs` to utilize new API with explicit null flags (id: non-nullable, name: nullable)
- Maintains backward compatibility with existing column definitions
- Includes test coverage for both nullable and non-nullable scenarios



<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for specifying whether each table column allows null values when registering tables.

- **Bug Fixes**
	- Ensured that table schemas accurately reflect column nullability settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->