### PR TITLE
Update README usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,26 @@ Note: This is WIP heavily and API can change.
 
 ## Example Usage
 
-Register the catalog tables into your existing `SessionContext`:
+Register the catalog tables into your existing `SessionContext` and add your own tables:
 
 ```rust
 use datafusion::execution::context::SessionContext;
+use arrow::datatypes::DataType;
+use pg_catalog_rs::{register_pg_catalog_tables, register_table};
 
 let ctx = SessionContext::new();
-pg_catalog_rs::register_pg_catalog_tables(&ctx).await?;
+register_pg_catalog_tables(&ctx).await?;
+
+register_table(
+    &ctx,
+    "crm",
+    "crm",
+    "users",
+    vec![
+        ("id", DataType::Int32, false),
+        ("name", DataType::Utf8, true),
+    ],
+)?;
 ```
 
 Then you can run queries like:


### PR DESCRIPTION
## Summary
- document register_table for adding user tables

## Testing
- `cargo test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848ccb0497c832fa8c73ef82f8a5841
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added an example to the README showing how to register user tables with the `register_table` function.

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

## Greptile Summary

Updated README.md to document the `register_table` functionality for adding custom user tables to the PostgreSQL catalog emulation layer.

- Added example code demonstrating `register_table` usage for custom table registration
- Documented proper column type handling for nullable and non-nullable fields
- Shows integration with existing pg_catalog_tables functionality



<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded the README example to show how to register both built-in PostgreSQL catalog tables and custom user-defined tables, including necessary imports and usage steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->