### PR TITLE
Document router usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,20 @@ SELECT attname FROM pg_attribute WHERE attrelid = 12345;
 
 Or use DBeaver/psql to introspect the schema.
 
+## Query Routing with `dispatch_query`
+
+When executing SQL, call [`dispatch_query`](src/router.rs) to automatically
+route catalog queries to the internal handler while forwarding all other
+statements to your application logic.
+
+```rust
+use pg_catalog_rs::router::dispatch_query;
+
+let result = dispatch_query(&ctx, "SELECT * FROM pg_class", |ctx, sql| async move {
+    ctx.sql(sql).await?.collect().await
+}).await?;
+```
+
 ---
 
 ## Integration


### PR DESCRIPTION
## Summary
- document the router module
- explain query routing in README

## Testing
- `cargo test`
- `pytest -q`
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_68491e58602c832f8b9bcaa656d10b98
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added documentation for the router module and updated the README to explain how to use query routing with `dispatch_query`.

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

## Greptile Summary

Added documentation for the query routing system, explaining how queries are dispatched between catalog and user tables in the PostgreSQL-compatible interface.

- Added comprehensive documentation in `src/router.rs` detailing table routing logic and search path behavior
- Updated `README.md` with new section explaining query routing functionality and dispatch_query mechanism
- Documentation preserves implementation while adding clear examples and usage patterns
- Changes are purely documentation-focused with no functional modifications



<!-- /greptile_comment -->