### PR TITLE
Route catalog queries via router dispatch

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -77,8 +77,8 @@ async fn run() -> anyhow::Result<()> {
         ],
     )?;
 
-    let _ = dispatch_query(&ctx, "SELECT 1", |_c, _q| async {
-        Ok((Vec::new(), Arc::new(Schema::empty())))
+    let _ = dispatch_query(&ctx, "SELECT 1", None, None, |_c, _q, _p, _t| {
+        async { Ok((Vec::new(), Arc::new(Schema::empty()))) }
     })
     .await?;
 
@@ -113,8 +113,8 @@ mod tests {
     #[tokio::test]
     async fn test_dispatch_in_main() -> anyhow::Result<()> {
         let ctx = SessionContext::new();
-        dispatch_query(&ctx, "SELECT 1", |_c, _q| async {
-            Ok((Vec::new(), Arc::new(Schema::empty())))
+        dispatch_query(&ctx, "SELECT 1", None, None, |_c, _q, _p, _t| {
+            async { Ok((Vec::new(), Arc::new(Schema::empty()))) }
         })
         .await?;
         Ok(())


### PR DESCRIPTION
## Summary
- extend `router::dispatch_query` to accept parameters
- use `dispatch_query` in server query handlers
- update example and tests for dispatch

## Testing
- `cargo test -q -- --test-threads=1`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684968ae209c832fb634dbf84f853952
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated server query handlers to use the router's dispatch_query function, allowing parameterized queries and improving code consistency.

- **Refactors**
  - Extended dispatch_query to accept parameters and types.
  - Replaced direct execute_sql calls in server handlers with dispatch_query.
  - Updated tests and examples to cover new dispatch behavior.

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

## Greptile Summary

Enhanced query routing system by extending `router::dispatch_query` to handle parameterized queries, centralizing query execution through the router dispatch mechanism.

- Modified `src/router.rs` to support parameterized queries with new parameter and type handling
- Updated `src/server.rs` to route all queries through `dispatch_query` instead of direct `execute_sql` calls
- Added parameter passing support in both simple and extended query handlers
- Maintained existing catalog query routing while adding parameter support



<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced query handling to support optional parameters and parameter types, allowing more flexible query execution.
- **Bug Fixes**
  - Improved internal query dispatching to ensure parameters are correctly forwarded and processed.
- **Tests**
  - Added a new test to verify that query parameters are properly passed to handlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->