### PR TITLE
Return dummy users data via dispatcher

### DIFF
--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -502,8 +502,8 @@ def test_rewrite_trigger_counts(server):
     )
     with psycopg.connect(CONN_STR) as conn:
         cur = conn.cursor()
-        with pytest.raises(Exception):
-            cur.execute(sql)
+        cur.execute(sql)
+        cur.fetchone()
 
 
 
@@ -544,6 +544,14 @@ def test_error_logging():
 
     assert "exec_error" in out
     assert "missing_table" in out
+
+
+def test_users_dummy_data(server):
+    with psycopg.connect(CONN_STR) as conn:
+        cur = conn.cursor()
+        cur.execute("SELECT * FROM users ORDER BY id")
+        rows = cur.fetchall()
+        assert rows == [(1, "Alice"), (2, "Bob")]
 
 
 def test_capture_option(tmp_path):


### PR DESCRIPTION
## Summary
- route user queries through dispatcher by default
- inject dummy data for `users` table so callable path is visible
- adjust functional tests for new behaviour

## Testing
- `cargo test --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68497a3f0b80832f8f382d2ea6c0889e
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
User queries to the users table now return dummy data through the dispatcher, making the callable path visible for development and testing.

- **Testing**
 - Updated functional tests to check for the new dummy users data.

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

## Greptile Summary

Implemented dummy data handling for user queries in PostgreSQL catalog emulation, enabling query path testing through a dispatcher system.

- Modified `src/server.rs` to intercept 'users' table queries and return predefined data for Alice and Bob
- Updated `tests/test_functional.py` to validate dummy data returns instead of throwing exceptions
- Added catalog entries for users table in pg_catalog for schema consistency
- Code duplication present in SimpleQueryHandler and ExtendedQueryHandler implementations needs attention



<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Queries to the "users" table now return sample data with two rows: (1, "Alice") and (2, "Bob").

- **Tests**
  - Added a test to verify that querying the "users" table returns the expected sample data.
  - Updated an existing test to remove the expectation of an exception when executing certain queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->