### PR TITLE
Enable dynamic user table registration

### DIFF
--- a/src/pg_catalog_helpers.rs
+++ b/src/pg_catalog_helpers.rs
@@ -88,56 +88,127 @@ use sqlparser::parser::Parser;
 use sqlparser::ast::Statement;
 
 
-pub async fn register_user_tables(ctx: &SessionContext) -> DFResult<()> {
-    // 1. pg_class (row for oid 50010)
+use std::sync::atomic::{AtomicI32, Ordering};
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ColumnDef {
+    #[serde(rename = "type")]
+    pub col_type: String,
+    pub nullable: bool,
+}
+
+static NEXT_OID: AtomicI32 = AtomicI32::new(50010);
+
+fn map_type_to_oid(t: &str) -> i32 {
+    match t.to_lowercase().as_str() {
+        "int" | "integer" | "int4" => 23,
+        "bigint" | "int8" => 20,
+        "bool" | "boolean" => 16,
+        _ => 25, // default to text
+    }
+}
+
+pub async fn register_user_tables(
+    ctx: &SessionContext,
+    table_name: &str,
+    columns: Vec<BTreeMap<String, ColumnDef>>,
+) -> DFResult<()> {
+    let table_oid = NEXT_OID.fetch_add(1, Ordering::SeqCst);
+    let type_oid = NEXT_OID.fetch_add(1, Ordering::SeqCst);
+
     if ctx
-        .sql("SELECT 1 FROM pg_catalog.pg_class WHERE oid = 50010")
+        .sql(&format!(
+            "SELECT 1 FROM pg_catalog.pg_class WHERE oid = {table_oid}"
+        ))
         .await?
         .count()
         .await?
         == 0
     {
-        ctx.sql("INSERT INTO pg_catalog.pg_class
-                 (oid, relname, relnamespace, relkind, reltuples, reltype, relispartition)
-                 VALUES (50010,'users',2200,'r',0,50011, false)")
-            .await?
-            .collect()
-            .await?;
+        let sql = format!(
+            "INSERT INTO pg_catalog.pg_class \
+                 (oid, relname, relnamespace, relkind, reltuples, reltype, relispartition) \
+                 VALUES ({table_oid},'{}',2200,'r',0,{type_oid}, false)",
+            table_name.replace('\'', "''")
+        );
+        ctx.sql(&sql).await?.collect().await?;
     }
 
-    // 2. pg_type (row for oid 50011)
     if ctx
-        .sql("SELECT 1 FROM pg_catalog.pg_type WHERE oid = 50011")
+        .sql(&format!(
+            "SELECT 1 FROM pg_catalog.pg_type WHERE oid = {type_oid}"
+        ))
         .await?
         .count()
         .await?
         == 0
     {
-        ctx.sql("INSERT INTO pg_catalog.pg_type
-                 (oid, typname, typrelid, typlen, typcategory)
-                 VALUES (50011,'_users',50010,-1,'C')")
-            .await?
-            .collect()
-            .await?;
+        let sql = format!(
+            "INSERT INTO pg_catalog.pg_type \
+                 (oid, typname, typrelid, typlen, typcategory) \
+                 VALUES ({type_oid},'_{table_name}',{table_oid},-1,'C')"
+        );
+        ctx.sql(&sql).await?.collect().await?;
     }
 
-    // 3. pg_attribute (rows for attrelid 50010)
-    if ctx
-        .sql("SELECT 1 FROM pg_catalog.pg_attribute
-              WHERE attrelid = 50010 AND attnum = 1")
-        .await?
-        .count()
-        .await?
-        == 0
-    {
-        ctx.sql("INSERT INTO pg_catalog.pg_attribute
-                 (attrelid,attnum,attname,atttypid,atttypmod,attnotnull,attisdropped)
-                 VALUES
-                 (50010,1,'id',23,-1,false,false),
-                 (50010,2,'name',25,-1,false,false)")
-            .await?
-            .collect()
-            .await?;
+    for (idx, col) in columns.iter().enumerate() {
+        let (name, def) = col.iter().next().unwrap();
+        let atttypid = map_type_to_oid(&def.col_type);
+        let notnull = if def.nullable { "false" } else { "true" };
+        let sql = format!(
+            "INSERT INTO pg_catalog.pg_attribute \
+                 (attrelid,attnum,attname,atttypid,atttypmod,attnotnull,attisdropped) \
+                 VALUES ({table_oid},{},'{}',{atttypid},-1,{notnull},false)",
+            idx + 1,
+            name.replace('\'', "''")
+        );
+        ctx.sql(&sql).await?.collect().await?;
     }
+
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::get_base_session_context;
+
+    #[tokio::test]
+    async fn test_register_user_tables_dynamic() -> DFResult<()> {
+        let (ctx, _) = get_base_session_context(
+            &"pg_catalog_data/pg_schema".to_string(),
+            "pgtry".to_string(),
+            "public".to_string(),
+        )
+        .await?;
+
+        let mut c1 = BTreeMap::new();
+        c1.insert(
+            "id".to_string(),
+            ColumnDef { col_type: "int".to_string(), nullable: true },
+        );
+        let mut c2 = BTreeMap::new();
+        c2.insert(
+            "name".to_string(),
+            ColumnDef { col_type: "text".to_string(), nullable: true },
+        );
+
+        register_user_tables(&ctx, "contacts", vec![c1, c2]).await?;
+
+        let df = ctx
+            .sql("SELECT relname FROM pg_catalog.pg_class WHERE relname='contacts'")
+            .await?;
+        assert_eq!(df.count().await?, 1);
+
+        let df = ctx
+            .sql(
+                "SELECT attname FROM pg_catalog.pg_attribute \
+                 WHERE attrelid = (SELECT oid FROM pg_catalog.pg_class WHERE relname='contacts') \
+                 ORDER BY attnum",
+            )
+            .await?;
+        let batches = df.collect().await?;
+        assert_eq!(batches[0].num_rows(), 2);
+        Ok(())
+    }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1294,7 +1294,12 @@ pub async fn start_server(
             let df = ctx.sql("select datname from pg_catalog.pg_database").await?;
             df.show().await?;
             
-            pg_rs::register_user_tables(&ctx).await?;
+            use pg_rs::ColumnDef;
+            let mut c1 = BTreeMap::new();
+            c1.insert("id".to_string(), ColumnDef { col_type: "int".to_string(), nullable: true });
+            let mut c2 = BTreeMap::new();
+            c2.insert("name".to_string(), ColumnDef { col_type: "text".to_string(), nullable: true });
+            pg_rs::register_user_tables(&ctx, "users", vec![c1, c2]).await?;
 
 
             let factory = Arc::new(DatafusionBackendFactory {


### PR DESCRIPTION
## Summary
- extend `register_user_tables` to accept a table name and column definition list
- register the sample `users` table in `server.rs` using the new API
- cover the new behaviour with a unit test

## Testing
- `cargo test --all-targets`

------
https://chatgpt.com/codex/tasks/task_e_684986f910e4832f868e2be3c1758d98
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Made user table registration dynamic by allowing custom table names and column definitions. Added a unit test and updated server startup to use the new API.

- **New Features**
  - `register_user_tables` now accepts a table name and column definitions.
  - Server registers the `users` table using the new API.
  - Added a test for dynamic table registration.

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

## Greptile Summary

Enhances table registration functionality by making `register_user_tables` dynamic and configurable in the PostgreSQL catalog emulator.

- Implemented dynamic table registration in `src/pg_catalog_helpers.rs` with new `ColumnDef` struct and type mapping
- Added atomic OID generation to replace hardcoded values, improving system reliability
- Modified `src/server.rs` to use new API for registering sample 'users' table with 'id' and 'name' columns
- Introduced SQL injection protection through proper string escaping
- Added comprehensive unit tests for the new dynamic registration functionality



<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced support for dynamic registration of user tables with customizable table names and column definitions.
  - Columns can now be defined with specific types and nullability when registering tables.
- **Tests**
  - Added tests to verify correct registration, querying, and idempotency of dynamically registered tables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->