### PR TITLE
Expose pg_catalog as library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,10 @@
 name = "datafusion_pg_catalog"
 version = "0.1.0"
 edition = "2021"
+publish = false
+
+[lib]
+path = "src/lib.rs"
 
 [dependencies]
 datafusion = "47.0.0"

--- a/README.md
+++ b/README.md
@@ -33,6 +33,17 @@ Note: This is WIP heavily and API can change.
 
 ---
 
+## Installation
+
+Add the crate from GitHub to your `Cargo.toml`:
+
+```toml
+[dependencies]
+datafusion_pg_catalog = { git = "https://github.com/ybrs/pg_catalog" }
+```
+
+---
+
 ## Example Usage
 
 Register the catalog tables into your existing `SessionContext` and add your own tables:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,18 @@
+// Library module for pg_catalog functionality.
+// Exposes modules so the crate can be used as a library as well as a binary.
+
+pub mod clean_duplicate_columns;
+pub mod register_table;
+pub mod server;
+pub mod db_table;
+pub mod replace;
+pub mod session;
+pub mod logical_plan_rules;
+pub mod scalar_to_cte;
+pub mod replace_any_group_by;
+pub mod router;
+pub mod user_functions;
+pub mod pg_catalog_helpers;
+
+// Re-export all public functions from pg_catalog_helpers for convenience.
+pub use pg_catalog_helpers::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,27 +2,16 @@
 // Parses CLI arguments, builds a SessionContext and starts the pgwire server.
 // Provides a simple way to run the DataFusion-backed PostgreSQL emulator.
 
-mod session;
-mod replace;
-mod clean_duplicate_columns;
-mod server;
-mod user_functions;
-mod db_table;
-mod logical_plan_rules;
-mod scalar_to_cte;
-mod replace_any_group_by;
-mod register_table;
-mod router;
-mod pg_catalog_helpers;
+
 
 use std::env;
 use std::sync::Arc;
 // use arrow::util::pretty;
-use crate::server::start_server;
-use crate::session::{get_base_session_context};
-use register_table::register_table;
+use datafusion_pg_catalog::server::start_server;
+use datafusion_pg_catalog::session::get_base_session_context;
+use datafusion_pg_catalog::register_table::register_table;
 use arrow::datatypes::{DataType, Schema};
-use router::dispatch_query;
+use datafusion_pg_catalog::router::dispatch_query;
 
 async fn run() -> anyhow::Result<()> {
     let args: Vec<String> = env::args().collect();
@@ -106,7 +95,7 @@ async fn main() -> anyhow::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use datafusion_pg_catalog::router::dispatch_query;
     use datafusion::execution::context::SessionContext;
     use std::sync::Arc;
     use arrow::datatypes::Schema;


### PR DESCRIPTION
## Summary
- add library target and mark crate unpublished
- export pg_catalog helpers through new `lib.rs`
- update `main.rs` to use library modules
- provide installation instructions

## Testing
- `cargo test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684992876e34832f9ecc429af2ed631b
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Made the crate usable as a library by exposing pg_catalog helpers and updating the main binary to use the new library modules.

- **Migration**
  - Add the crate as a GitHub dependency in your `Cargo.toml` to use it as a library.

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

## Greptile Summary

Restructures the project to expose pg_catalog as a reusable library crate while maintaining the existing binary functionality. The changes add library support through Cargo.toml configuration and introduce a new public API surface.

- Added new `src/lib.rs` to serve as the library entry point and define public API
- Modified `Cargo.toml` to add library target and set `publish = false` to prevent accidental publishing
- Refactored `src/main.rs` to use the new library imports instead of local module declarations
- Updated `README.md` with installation instructions and import path examples using `datafusion_pg_catalog`



<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a library module to organize and expose multiple public modules for enhanced functionality.
  - Added public re-exports for easier access to key components.

- **Documentation**
  - Added an "Installation" section to the README with instructions for including the crate from GitHub.

- **Chores**
  - Updated project configuration to prevent publishing to public registries and specify the library source path.
  - Adjusted imports to use modules from the external crate rather than local paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->