### PR TITLE
Expose dispatch_query and add API test

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,3 +16,5 @@ pub mod pg_catalog_helpers;
 
 // Re-export all public functions from pg_catalog_helpers for convenience.
 pub use pg_catalog_helpers::*;
+// Re-export dispatch_query at crate root for convenience.
+pub use router::dispatch_query;

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -1,0 +1,23 @@
+use datafusion_pg_catalog::dispatch_query;
+use datafusion::execution::context::SessionContext;
+use arrow::datatypes::Schema;
+use std::sync::{Arc, Mutex};
+
+#[tokio::test]
+async fn test_dispatch_query_public() -> datafusion::error::Result<()> {
+    let ctx = SessionContext::new();
+
+    let called = Arc::new(Mutex::new(false));
+    let called_clone = called.clone();
+    let handler = move |_ctx: &SessionContext, _sql: &str, _p, _t| {
+        let called_clone = called_clone.clone();
+        async move {
+            *called_clone.lock().unwrap() = true;
+            Ok((Vec::new(), Arc::new(Schema::empty())))
+        }
+    };
+
+    dispatch_query(&ctx, "SELECT 1", None, None, handler).await?;
+    assert!(*called.lock().unwrap());
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- re-export `dispatch_query` from library
- add new Rust integration test for public API exposure

## Testing
- `cargo test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849dac71064832fa8463f69c2e3c0b3
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Re-exported the dispatch_query function at the crate root and added a Rust integration test to check its public API exposure.

- **New Features**
  - dispatch_query is now available directly from the crate root.
  - Added a test to verify dispatch_query is publicly accessible.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Made the `dispatch_query` function accessible directly from the crate root for easier use.

- **Tests**
  - Added a new test to verify public access and correct invocation of the `dispatch_query` function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

## Greptile Summary

Exposes the `dispatch_query` router function at the crate's public API level, enabling external consumers to handle SQL query routing in the PostgreSQL catalog emulation system.

- Added `tests/public_api.rs` with integration tests validating the exposed `dispatch_query` functionality
- Modified `src/lib.rs` to re-export the `dispatch_query` function from the router module
- New API allows external handlers to intercept and process SQL queries based on table references



<!-- /greptile_comment -->