### PR TITLE
Cleanup refactor

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -56,21 +56,21 @@ async fn run() -> anyhow::Result<()> {
 
     let (ctx, log) = get_base_session_context(schema_path, default_catalog.clone(), default_schema.clone()).await?;
 
-    register_table(
-        &ctx,
-        "crm",
-        "crm",
-        "users",
-        vec![
-            ("id", DataType::Int32, false),
-            ("name", DataType::Utf8, true),
-        ],
-    )?;
+    // register_table(
+    //     &ctx,
+    //     "crm",
+    //     "crm",
+    //     "users",
+    //     vec![
+    //         ("id", DataType::Int32, false),
+    //         ("name", DataType::Utf8, true),
+    //     ],
+    // )?;
 
-    let _ = dispatch_query(&ctx, "SELECT 1", None, None, |_c, _q, _p, _t| {
-        async { Ok((Vec::new(), Arc::new(Schema::empty()))) }
-    })
-    .await?;
+    // let _ = dispatch_query(&ctx, "SELECT 1", None, None, |_c, _q, _p, _t| {
+    //     async { Ok((Vec::new(), Arc::new(Schema::empty()))) }
+    // })
+    // .await?;
 
     start_server(
         Arc::new(ctx),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,13 @@
 // Entry point for the pg_catalog compatibility server.
 // Parses CLI arguments, builds a SessionContext and starts the pgwire server.
 // Provides a simple way to run the DataFusion-backed PostgreSQL emulator.
-
-
-
+use std::collections::BTreeMap;
 use std::env;
 use std::sync::Arc;
+use datafusion_pg_catalog::pg_catalog_helpers;
 // use arrow::util::pretty;
-use datafusion_pg_catalog::server::start_server;
+use datafusion_pg_catalog::{server::start_server, session::register_database_to_pg_catalog};
 use datafusion_pg_catalog::session::get_base_session_context;
-use datafusion_pg_catalog::register_table::register_table;
-use arrow::datatypes::{DataType, Schema};
-use datafusion_pg_catalog::router::dispatch_query;
 
 async fn run() -> anyhow::Result<()> {
     let args: Vec<String> = env::args().collect();
@@ -56,21 +52,13 @@ async fn run() -> anyhow::Result<()> {
 
     let (ctx, log) = get_base_session_context(schema_path, default_catalog.clone(), default_schema.clone()).await?;
 
-    // register_table(
-    //     &ctx,
-    //     "crm",
-    //     "crm",
-    //     "users",
-    //     vec![
-    //         ("id", DataType::Int32, false),
-    //         ("name", DataType::Utf8, true),
-    //     ],
-    // )?;
-
-    // let _ = dispatch_query(&ctx, "SELECT 1", None, None, |_c, _q, _p, _t| {
-    //     async { Ok((Vec::new(), Arc::new(Schema::empty()))) }
-    // })
-    // .await?;
+    register_database_to_pg_catalog(&ctx).await?;
+    use pg_catalog_helpers::ColumnDef;
+    let mut c1 = BTreeMap::new();
+    c1.insert("id".to_string(), ColumnDef { col_type: "int".to_string(), nullable: true });
+    let mut c2 = BTreeMap::new();
+    c2.insert("name".to_string(), ColumnDef { col_type: "text".to_string(), nullable: true });
+    pg_catalog_helpers::register_user_tables(&ctx, "users", vec![c1, c2]).await?;
 
     start_server(
         Arc::new(ctx),

--- a/src/pg_catalog_helpers.rs
+++ b/src/pg_catalog_helpers.rs
@@ -1,92 +1,10 @@
 use datafusion::error::Result as DFResult;
-use std::sync::{Arc, Mutex};
-
-use async_trait::async_trait;
-use futures::{stream, Stream};
-use futures::stream::BoxStream;
-use arrow::array::{Array, ArrayRef, Float32Array, Float64Array};
-use pgwire::api::auth::{AuthSource, DefaultServerParameterProvider, LoginInfo, Password};
-use pgwire::api::auth::md5pass::{hash_md5_password, Md5PasswordAuthStartupHandler};
-use pgwire::api::copy::NoopCopyHandler;
-use pgwire::api::portal::{Format, Portal};
-use pgwire::api::query::{ExtendedQueryHandler, SimpleQueryHandler};
-use pgwire::api::results::{DataRowEncoder, DescribePortalResponse, DescribeStatementResponse, FieldFormat, FieldInfo, QueryResponse, Response, Tag};
-use pgwire::api::stmt::{NoopQueryParser, StoredStatement};
-use pgwire::api::{ClientInfo, PgWireServerHandlers, Type};
-use pgwire::error::{PgWireError, PgWireResult};
-use pgwire::messages::data::DataRow;
-use pgwire::tokio::process_socket;
-use tokio::net::TcpListener;
-use serde::{Serialize, Deserialize};
-use bytes::Bytes;
+use serde::{Deserialize};
 use std::collections::BTreeMap;
-use std::fs::File;
-use std::io::Write;
-use std::path::PathBuf;
-
-use arrow::array::{BooleanArray, Int32Array, Int64Array, LargeStringArray, ListArray, StringArray, StringViewArray};
-use arrow::record_batch::RecordBatch;
 use datafusion::execution::context::SessionContext;
-
-use arrow::datatypes::{DataType, Field, Schema, SchemaRef, TimeUnit};
-
-use datafusion::{
-    logical_expr::{create_udf, Volatility, ColumnarValue},
+use datafusion::{    
     common::ScalarValue,
 };
-
-use crate::replace::{regclass_udfs};
-use crate::session::{execute_sql, ClientOpts};
-use crate::router::dispatch_query;
-use crate::user_functions::{
-    register_array_agg,
-    register_current_schema,
-    register_current_schemas,
-    register_pg_get_array,
-    register_oidvector_to_array,
-    register_pg_get_function_arguments,
-    register_pg_get_function_result,
-    register_pg_get_function_sqlbody,
-    register_pg_get_indexdef,
-    register_pg_get_triggerdef,
-    register_pg_get_ruledef,
-    register_pg_get_one,
-    register_pg_get_statisticsobjdef_columns,
-    register_pg_get_viewdef,
-    register_pg_get_keywords,
-    register_pg_available_extension_versions,
-    register_pg_postmaster_start_time,
-    register_pg_relation_is_publishable,
-    register_has_database_privilege,
-    register_has_schema_privilege,
-    register_pg_relation_size,
-    register_pg_total_relation_size,
-    register_quote_ident,
-    register_scalar_array_to_string,
-    register_scalar_format_type,
-    register_scalar_pg_age,
-    register_scalar_pg_encoding_to_char,
-    register_scalar_pg_get_expr,
-    register_scalar_pg_get_partkeydef,
-    register_scalar_pg_get_userbyid,
-    register_scalar_pg_is_in_recovery,
-    register_scalar_pg_table_is_visible,
-    register_scalar_pg_tablespace_location,
-    register_scalar_regclass_oid,
-    register_scalar_txid_current,
-    register_encode,
-    register_upper,
-    register_version_fn,
-    register_translate,
-};
-use tokio::net::TcpStream;
-use tokio::io::AsyncReadExt;
-use tokio::io::AsyncWriteExt;
-use log;
-use sqlparser::dialect::PostgreSqlDialect;
-use sqlparser::parser::Parser;
-use sqlparser::ast::Statement;
-
 
 use std::sync::atomic::{AtomicI32, Ordering};
 
@@ -113,11 +31,10 @@ pub async fn register_user_tables(
     table_name: &str,
     columns: Vec<BTreeMap<String, ColumnDef>>,
 ) -> DFResult<()> {
-    println!("registering user_tables");
-    let df = ctx.sql(&format!(
-            "SELECT 1 FROM pg_catalog.pg_class WHERE relname='{}'",
-            table_name.replace('\'', "''")
-        )).await?;
+    let df = ctx.sql("SELECT 1 FROM pg_catalog.pg_class WHERE relname='$relname'")
+        .await?.with_param_values(vec![
+           ("relname", ScalarValue::from(table_name))
+        ])?;
 
     if df.count().await? > 0 {
         return Ok(());

--- a/src/pg_catalog_helpers.rs
+++ b/src/pg_catalog_helpers.rs
@@ -113,12 +113,12 @@ pub async fn register_user_tables(
     table_name: &str,
     columns: Vec<BTreeMap<String, ColumnDef>>,
 ) -> DFResult<()> {
-    let df = ctx
-        .sql(&format!(
+    println!("registering user_tables");
+    let df = ctx.sql(&format!(
             "SELECT 1 FROM pg_catalog.pg_class WHERE relname='{}'",
             table_name.replace('\'', "''")
-        ))
-        .await?;
+        )).await?;
+
     if df.count().await? > 0 {
         return Ok(());
     }

--- a/src/pg_catalog_helpers.rs
+++ b/src/pg_catalog_helpers.rs
@@ -31,12 +31,13 @@ pub async fn register_user_tables(
     table_name: &str,
     columns: Vec<BTreeMap<String, ColumnDef>>,
 ) -> DFResult<()> {
-    let df = ctx.sql("SELECT 1 FROM pg_catalog.pg_class WHERE relname='$relname'")
+    let df = ctx.sql("SELECT 1 FROM pg_catalog.pg_class WHERE relname=$relname")
         .await?.with_param_values(vec![
            ("relname", ScalarValue::from(table_name))
         ])?;
 
     if df.count().await? > 0 {
+        println!("table already exists {:}?", table_name);
         return Ok(());
     }
 

--- a/src/register_table.rs
+++ b/src/register_table.rs
@@ -11,7 +11,8 @@ use datafusion::error::Result;
 /// Register a new datafusion memtable in the given catalog and schema.
 /// Creates the catalog or schema if it does not exist.
 /// Example: 
-/// ```
+/// ```text
+///  use datafusion_pg_catalog::register_table::register_table;
 ///  register_table(
 ///     &ctx,
 ///     "crm",

--- a/src/register_table.rs
+++ b/src/register_table.rs
@@ -72,7 +72,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_register_table() -> Result<()> {
-        let mut config = datafusion::execution::context::SessionConfig::new()
+        let config = datafusion::execution::context::SessionConfig::new()
             .with_default_catalog_and_schema("crm", "crm");
         let ctx = SessionContext::new_with_config(config);
 

--- a/src/register_table.rs
+++ b/src/register_table.rs
@@ -10,6 +10,23 @@ use datafusion::error::Result;
 
 /// Register a new datafusion memtable in the given catalog and schema.
 /// Creates the catalog or schema if it does not exist.
+/// Example: 
+/// ```
+///  register_table(
+///     &ctx,
+///     "crm",
+///     "crm",
+///     "users",
+///     vec![
+///         ("id", DataType::Int32, false),
+///         ("name", DataType::Utf8, true),
+///     ],
+/// )?;
+/// let _ = dispatch_query(&ctx, "SELECT 1", None, None, |_c, _q, _p, _t| {
+///     async { Ok((Vec::new(), Arc::new(Schema::empty()))) }
+/// })
+/// .await?;
+/// ```
 pub fn register_table(
     ctx: &SessionContext,
     catalog_name: &str,

--- a/src/replace_any_group_by.rs
+++ b/src/replace_any_group_by.rs
@@ -1,23 +1,7 @@
-use sqlparser::ast::*;
 use sqlparser::dialect::PostgreSqlDialect;
 use sqlparser::parser::Parser;
 use std::collections::HashSet;
 use std::ops::ControlFlow;
-use arrow::datatypes::DataType as ArrowDataType;
-use datafusion::logical_expr::{create_udf, ColumnarValue, ScalarUDF, Volatility};
-use datafusion::scalar::ScalarValue;
-
-use sqlparser::ast::{Expr, Function, FunctionArg, FunctionArgExpr, FunctionArguments, Ident, ObjectName, ObjectNamePart, Value};
-use datafusion::prelude::SessionContext;
-use sqlparser::ast::*;
-use sqlparser::tokenizer::Span;
-use sqlparser::ast::{
-    visit_expressions_mut, visit_statements_mut, ValueWithSpan,
-};
-use sqlparser::ast::{Statement};
-use sqlparser::ast::OneOrManyWithParens;
-use datafusion::error::{DataFusionError, Result};
-
 
 /// Add columns referenced inside `= ANY(...)` predicates to the
 /// `GROUP BY` clause so queries grouping on such expressions pass
@@ -48,7 +32,7 @@ pub fn rewrite_group_by_for_any(sql: &str) -> String {
 
     let mut touched = false;
 
-    visit_statements_mut(&mut statements, |stmt| {
+    let _cf = visit_statements_mut(&mut statements, |stmt| {
         if let Statement::Query(q) = stmt {
             if let SetExpr::Select(sel) = q.body.as_mut() {
                 // only deal with GROUP BY <exprs>, ignore GROUP BY ALL etc.

--- a/src/server.rs
+++ b/src/server.rs
@@ -1098,7 +1098,6 @@ impl PgWireServerHandlers for DatafusionBackendFactory {
     fn startup_handler(&self) -> Arc<Self::StartupHandler> {
         let mut params = DefaultServerParameterProvider::default();
         params.server_version = SERVER_VERSION.to_string();
-        println!("startup handler");
         Arc::new(Md5PasswordAuthStartupHandler::new(
             Arc::new(DummyAuthSource),
             Arc::new(params),

--- a/src/server.rs
+++ b/src/server.rs
@@ -31,7 +31,7 @@ use arrow::array::{BooleanArray, Int32Array, Int64Array, LargeStringArray, ListA
 use arrow::record_batch::RecordBatch;
 use datafusion::execution::context::SessionContext;
 
-use arrow::datatypes::{DataType, Field, Schema, SchemaRef, TimeUnit};
+use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
 
 use datafusion::{
     logical_expr::{create_udf, Volatility, ColumnarValue},

--- a/src/session.rs
+++ b/src/session.rs
@@ -2,18 +2,12 @@
 // Loads YAML schemas into MemTables, registers UDFs and executes rewritten queries using DataFusion.
 // Separated to encapsulate DataFusion setup and query execution behaviour.
 
-use arrow::array::{Int32Array, StringArray, ArrayRef};
+use arrow::array::{Int32Array, ArrayRef};
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
-
-use datafusion::catalog::{SchemaProvider, Session};
-
 use datafusion::catalog::memory::{MemoryCatalogProvider, MemorySchemaProvider};
-use datafusion::datasource::{MemTable};
 use datafusion::error::DataFusionError;
 use datafusion::execution::context::SessionContext;
 use arrow::record_batch::RecordBatch;
-
-use datafusion::execution::{SessionState, SessionStateBuilder};
 use serde::Deserialize;
 use serde_yaml;
 


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Major refactoring of PostgreSQL catalog emulation code, focusing on improved session management, security, and code organization across core components.

- Enhanced security in `src/pg_catalog_helpers.rs` by implementing parameterized queries to prevent SQL injection
- Streamlined session initialization in `src/session.rs` by consolidating catalog registration logic and fixing duplicate `regclass_oid` UDTF registration
- Simplified server architecture in `src/server.rs` by removing direct dependencies on pg_catalog_helpers and moving initialization code
- Improved table registration process in `src/main.rs` using BTreeMap and organized pg_catalog registration sequence
- Added comprehensive documentation in `src/register_table.rs` with practical code examples



<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved session setup and catalog registration for better modularity and extensibility.
  - Centralized and modernized user table and database registration, reducing manual schema construction.
  - Streamlined server initialization by reusing existing session context and removing redundant setup code.
  - Reduced unused imports for cleaner codebase.

- **Documentation**
  - Added a usage example to the user table registration documentation.

- **Style**
  - Cleaned up import statements across multiple files.

No changes to user-facing features or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->