### PR TITLE
Fix CI to build schema zip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
   
-        - name: Install Python dependencies
+      - name: Install Python dependencies
         run: pip install -r requirements.txt
 
       - name: Create schema zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,10 @@ jobs:
             ${{ runner.os }}-pip-
   
         - name: Install Python dependencies
-          run: pip install -r requirements.txt
+        run: pip install -r requirements.txt
+
+      - name: Create schema zip
+        run: make create_schema_zip
 
         - name: Create schema zip
           run: make create_schema_zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
   
-      - name: Install Python dependencies
-        run: pip install -r requirements.txt
+        - name: Install Python dependencies
+          run: pip install -r requirements.txt
+
+        - name: Create schema zip
+          run: make create_schema_zip
 
       - name: Run cargo tests
         run: cargo test --all --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,10 +45,6 @@ jobs:
 
       - name: Create schema zip
         run: make create_schema_zip
-
-        - name: Create schema zip
-          run: make create_schema_zip
-
       - name: Run cargo tests
         run: cargo test --all --verbose
 

--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,11 @@ run_postgresql:
 	./run-postgres.sh
 
 create_schema_yaml_files:
-        python schema.py generate pg_catalog_data/pg_schema
+	python schema.py generate pg_catalog_data/pg_schema
 
 create_schema_zip:
-        zip -r pg_schema.zip pg_catalog_data/pg_schema
+	zip -r pg_schema.zip pg_catalog_data/pg_schema
 
 
 dev_server:
-        RUST_LOG=info RUST_MIN_STACK=33554432 cargo run ./pg_schema.zip --default-catalog pgtry --default-schema pg_catalog --port 5444
+	RUST_LOG=info RUST_MIN_STACK=33554432 cargo run -- ./pg_schema.zip --default-catalog pgtry --default-schema pg_catalog --port 5444


### PR DESCRIPTION
## Summary
- ensure CI builds `pg_schema.zip` before testing

## Testing
- `cargo test --all --verbose` *(fails: failed to download from `https://index.crates.io/config.json`)*
- `pytest -s` *(fails: KeyboardInterrupt while resolving crates)*

------
https://chatgpt.com/codex/tasks/task_e_684b3909d5ec832f9886982e36bb8062
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated the CI workflow to build the schema zip file before running tests. This ensures tests have the required schema archive.

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

## Greptile Summary

Updates GitHub Actions CI workflow to build `pg_schema.zip` before running tests, addressing a critical dependency issue in the test pipeline.

- Added schema zip file generation step in `.github/workflows/ci.yml` before test execution
- Tests are currently failing due to crates.io connectivity issues
- Requires proper error handling for crate resolution timeouts
- Package resolution issues indicate potential network/proxy configuration needs in CI



<!-- /greptile_comment -->