### PR TITLE
Fix Makefile tabs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,11 @@ run_postgresql:
 	./run-postgres.sh
 
 create_schema_yaml_files:
-        python schema.py generate pg_catalog_data/pg_schema
+	python schema.py generate pg_catalog_data/pg_schema
 
 create_schema_zip:
-        zip -r pg_schema.zip pg_catalog_data/pg_schema
+	zip -r pg_schema.zip pg_catalog_data/pg_schema
 
 
 dev_server:
-        RUST_LOG=info RUST_MIN_STACK=33554432 cargo run ./pg_schema.zip --default-catalog pgtry --default-schema pg_catalog --port 5444
+	RUST_LOG=info RUST_MIN_STACK=33554432 cargo run ./pg_schema.zip --default-catalog pgtry --default-schema pg_catalog --port 5444

--- a/Makefile
+++ b/Makefile
@@ -12,4 +12,4 @@ create_schema_zip:
 
 
 dev_server:
-	RUST_LOG=info RUST_MIN_STACK=33554432 cargo run ./pg_schema.zip --default-catalog pgtry --default-schema pg_catalog --port 5444
+	RUST_LOG=info RUST_MIN_STACK=33554432 cargo run -- ./pg_schema.zip --default-catalog pgtry --default-schema pg_catalog --port 5444


### PR DESCRIPTION
## Summary
- convert spaces to tabs in Makefile

## Testing
- `cargo test` *(fails: failed to download crates)*
- `pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_684b3ea82e08832f9d62f18a680d98e5
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Replaced spaces with tabs in the Makefile to fix command execution issues.

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

## Greptile Summary

Fixed critical syntax issue in `Makefile` by converting spaces to tabs for command indentation, which is required for Make functionality.

- Corrected indentation in `Makefile` from spaces to tabs to fix Make recipe parsing
- Cargo test failure (`failed to download crates`) suggests potential network or dependency issues unrelated to Makefile changes
- Pytest interruption needs investigation, though likely unrelated to Makefile modifications
- Testing section shows two failing tests that require resolution before merging



<!-- /greptile_comment -->