### PR TITLE
Add nightly schema release step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,3 +60,16 @@ jobs:
           name: tarpaulin-report
           path: cobertura.xml
 
+      - name: Zip schema files
+        if: github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main'
+        run: zip -r postgres-schema-nightly.zip pg_catalog_data/pg_schema
+
+      - name: Upload schema to release
+        if: github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main'
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: schema-nightly-${{ github.run_id }}
+          name: postgres-schema-nightly
+          prerelease: true
+          files: postgres-schema-nightly.zip
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: write
 
 on:
   pull_request:
@@ -61,11 +63,11 @@ jobs:
           path: cobertura.xml
 
       - name: Zip schema files
-        if: github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: zip -r postgres-schema-nightly.zip pg_catalog_data/pg_schema
 
       - name: Upload schema to release
-        if: github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: softprops/action-gh-release@v1
         with:
           tag_name: schema-nightly-${{ github.run_id }}


### PR DESCRIPTION
## Summary
- upload nightly schema build as part of CI

## Testing
- `cargo test --all --verbose --color=never`
- `pytest tests/test_functional.py::test_query_returns_text -q`


------
https://chatgpt.com/codex/tasks/task_e_684b4dea8060832faf231d5c78194c3a
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a nightly step to zip and upload the schema files as a prerelease when changes are merged into main. This helps automate sharing the latest schema builds.

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

## Greptile Summary

Added GitHub workflow configuration to automatically create nightly schema releases, enabling automated distribution of schema builds.

- Modified `.github/workflows/ci.yml` to add schema zip file creation and upload step
- Configured GitHub Actions to create pre-releases when changes merge to main
- Automated schema distribution process now happens as part of CI workflow
- Need to ensure GitHub token has sufficient permissions for release creation



<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated CI workflow to automatically create and upload a zip archive of the PostgreSQL schema as a prerelease asset on pushes to the main branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->