### PR TITLE
Fix release trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: write
 
 on:
   pull_request:
@@ -61,11 +63,11 @@ jobs:
           path: cobertura.xml
 
       - name: Zip schema files
-        if: github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: zip -r postgres-schema-nightly.zip pg_catalog_data/pg_schema
 
       - name: Upload schema to release
-        if: github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: softprops/action-gh-release@v1
         with:
           tag_name: schema-nightly-${{ github.run_id }}


### PR DESCRIPTION
## Summary
- push release to `schema-nightly` when merging to main

## Testing
- `cargo test --all --quiet`
- `pytest -s`


------
https://chatgpt.com/codex/tasks/task_e_684bee04d724832fa44333c1856ef47e
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed the release workflow to upload the schema zip to the nightly release when merging to main. Now, the release triggers only on pushes to the main branch.

<!-- End of auto-generated description by cubic. -->

