### PR TITLE
Add build script for pg schema

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "datafusion_pg_catalog"
 version = "0.1.0"
 edition = "2021"
 publish = false
+build = "build.rs"
 
 [lib]
 path = "src/lib.rs"
@@ -27,6 +28,9 @@ log = "0.4.27"
 env_logger = "0.11"
 once_cell = "1.21.3"
 datafusion-functions-aggregate = "47.0.0"
+zip = "0.6"
+
+[build-dependencies]
 zip = "0.6"
 
 [dev-dependencies]

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,64 @@
+use std::env;
+use std::fs::{self, File};
+use std::path::Path;
+use std::process::Command;
+
+fn main() {
+    let out_dir = env::var("OUT_DIR").expect("OUT_DIR env var not set");
+    let schema_dir = Path::new(&out_dir).join("pg_schema");
+    fs::create_dir_all(&schema_dir).expect("failed to create schema dir");
+
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let local_dir = Path::new(&manifest_dir).join("pg_catalog_data/pg_schema");
+
+    let marker = schema_dir.join("pg_class.yaml");
+    if !marker.exists() {
+        if local_dir.exists() {
+            copy_dir(&local_dir, &schema_dir).expect("failed to copy local schema");
+        } else {
+            let zip_path = Path::new(&out_dir).join("postgres-schema-nightly.zip");
+            if !zip_path.exists() {
+                if let Err(e) = download_zip(&zip_path) {
+                    panic!("failed to download schema: {}", e);
+                }
+            }
+            unzip_schema(&zip_path, &schema_dir);
+        }
+    }
+    println!("cargo:rustc-env=DEFAULT_SCHEMA_DIR={}", schema_dir.display());
+    println!("cargo:rerun-if-changed=build.rs");
+}
+
+fn download_zip(zip_path: &Path) -> Result<(), String> {
+    let url = "https://github.com/ybrs/pg_catalog/releases/download/schema-nightly-15632378697/postgres-schema-nightly.zip";
+    let status = Command::new("curl")
+        .arg("-L")
+        .arg("-o")
+        .arg(zip_path)
+        .arg(url)
+        .status()
+        .map_err(|e| format!("failed to execute curl: {}", e))?;
+    if !status.success() {
+        return Err(format!("curl failed with status: {}", status));
+    }
+    Ok(())
+}
+
+fn unzip_schema(zip_path: &Path, dest: &Path) {
+    let file = File::open(zip_path).expect("failed to open zip file");
+    let mut archive = zip::ZipArchive::new(file).expect("invalid zip archive");
+    archive.extract(dest).expect("failed to extract zip");
+}
+
+fn copy_dir(src: &Path, dst: &Path) -> std::io::Result<()> {
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_file() {
+            let file_name = path.file_name().unwrap();
+            fs::copy(&path, dst.join(file_name))?;
+        }
+    }
+    Ok(())
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,3 +19,6 @@ pub use pg_catalog_helpers::*;
 pub use router::dispatch_query;
 pub use server::start_server;
 pub use session::get_base_session_context;
+
+/// Path to the extracted `pg_schema` directory downloaded at build time.
+pub const DEFAULT_SCHEMA_DIR: &str = env!("DEFAULT_SCHEMA_DIR");

--- a/tests/build_script.rs
+++ b/tests/build_script.rs
@@ -1,0 +1,6 @@
+#[test]
+fn test_default_schema_dir_exists() {
+    let path = datafusion_pg_catalog::DEFAULT_SCHEMA_DIR;
+    let entries: Vec<_> = std::fs::read_dir(path).expect("schema dir missing").collect();
+    assert!(!entries.is_empty(), "schema directory should contain files");
+}


### PR DESCRIPTION
## Summary
- provide `build.rs` to fetch schema zip or copy local schema
- expose `DEFAULT_SCHEMA_DIR` constant
- download schema during build and set build env var
- test that schema dir exists

## Testing
- `cargo test --lib --quiet`
- `pytest -s`


------
https://chatgpt.com/codex/tasks/task_e_684c297f1fb4832fa206f9caddff7fe0
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a build script to fetch or copy the Postgres schema at build time and set the schema directory as a constant.

- **New Features**
  - Downloads the schema zip or copies a local schema during build.
  - Exposes DEFAULT_SCHEMA_DIR for use in code.
  - Adds a test to check the schema directory exists.

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

## Greptile Summary

Adds build-time schema management through `build.rs` to automatically handle PostgreSQL catalog schema files during compilation, improving development setup reliability.

- Added `build.rs` script to fetch schema zip from GitHub releases or copy from local directory
- Modified `Cargo.toml` to include build script configuration and zip crate dependency
- Added `DEFAULT_SCHEMA_DIR` constant in `src/lib.rs` for consistent schema file location
- Created `tests/build_script.rs` to verify schema directory setup and file presence



<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Automated setup of a PostgreSQL schema directory during the build process, including downloading and extracting schema files if not present locally.
  - Added a public constant for accessing the default schema directory path at runtime.

- **Tests**
  - Introduced a test to verify the existence and contents of the default schema directory after building.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->