### PR TITLE
Add README and example tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Run cargo tests
         run: cargo test --all --verbose
 
+      - name: Build example
+        run: cargo build --manifest-path example/Cargo.toml
+
       - name: Run python tests
         run: pytest -s
 

--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,27 @@
+# Example Usage
+
+This `pg_catalog_example` crate shows how to route SQL statements between an in-memory SQLite
+connection and the `pg_catalog` emulation provided by this repository.
+
+## Building
+
+```bash
+cargo build
+```
+
+## Running
+
+Pass the SQL query as an argument to `cargo run`:
+
+```bash
+cargo run -- "SELECT name FROM users ORDER BY id"
+```
+
+The above query is executed against the embedded SQLite database.
+
+Queries that reference `pg_catalog` are handled by the catalog layer:
+
+```bash
+cargo run -- "SELECT datname FROM pg_catalog.pg_database LIMIT 1"
+```
+

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -1,0 +1,25 @@
+import os
+import subprocess
+
+EXAMPLE_DIR = os.path.join(os.path.dirname(__file__), "..", "example")
+
+
+def run_example(query: str) -> str:
+    result = subprocess.run(
+        ["cargo", "run", "--quiet", "--", query],
+        cwd=EXAMPLE_DIR,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    return result.stdout
+
+
+def test_sqlite_query():
+    out = run_example("SELECT name FROM users ORDER BY id")
+    assert "Alice" in out and "Bob" in out
+
+
+def test_pg_catalog_query():
+    out = run_example("SELECT datname FROM pg_catalog.pg_database LIMIT 1")
+    assert "postgres" in out


### PR DESCRIPTION
## Summary
- add README to the example crate
- run example from pytest and check output
- ensure CI builds the example crate

## Testing
- `cargo test --all -- --test-threads=1`
- `pytest -s tests/test_example.py`


------
https://chatgpt.com/codex/tasks/task_e_684d89fdf4b0832fb494eac130deccf5
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a README and example tests for the example crate, and updated CI to build and test the example.

- **New Features**
  - Added a README with usage instructions for the example crate.
  - Added Python tests to check example output.
  - Updated CI to build and test the example crate.

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

## Greptile Summary

Added comprehensive testing and documentation support for the example crate, focusing on SQLite and pg_catalog integration demonstration.

- Added CI build step in `.github/workflows/ci.yml` to ensure example crate builds successfully
- Created `tests/test_example.py` for integration testing of example CLI app via subprocess calls
- Added `example/README.md` with build instructions and query examples for SQLite/pg_catalog routing



<!-- /greptile_comment -->