### PR TITLE
Separate example tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,10 @@ jobs:
         run: cargo build --manifest-path example/Cargo.toml
 
       - name: Run python tests
-        run: pytest -s
+        run: pytest -s tests
+
+      - name: Run example tests
+        run: pytest -s example/tests
 
       - name: Run rust coverage
         run: |

--- a/example/tests/test_example.py
+++ b/example/tests/test_example.py
@@ -1,7 +1,7 @@
 import os
 import subprocess
 
-EXAMPLE_DIR = os.path.join(os.path.dirname(__file__), "..", "example")
+EXAMPLE_DIR = os.path.join(os.path.dirname(__file__), "..")
 
 
 def run_example(query: str) -> str:


### PR DESCRIPTION
## Summary
- move Python example test under `example/tests`
- run example tests in a dedicated workflow step

## Testing
- `pytest -s tests` *(fails: KeyboardInterrupt)*
- `pytest -s example/tests/test_example.py::test_sqlite_query` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_684de67e8f68832fb4d8c55afcd1a16e
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Moved the Python example test to its own folder and set up a separate CI step to run example tests. This makes test organization clearer and CI runs more structured.

<!-- End of auto-generated description by cubic. -->

