### PR TITLE
Add schema registration utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,10 @@ datafusion_pg_catalog = { git = "https://github.com/ybrs/pg_catalog" }
 Create a `SessionContext` preloaded with the catalog tables and register your own schema:
 ```rust
 use std::collections::BTreeMap;
-use pg_catalog_rs::{get_base_session_context, register_user_database, register_user_tables, ColumnDef};
+use pg_catalog_rs::{
+    get_base_session_context, register_user_database, register_schema,
+    register_user_tables, ColumnDef,
+};
 
 let (ctx, _log) = get_base_session_context(
     Some("pg_catalog_data/pg_schema"),
@@ -58,13 +61,14 @@ let (ctx, _log) = get_base_session_context(
 ).await?;
 
 register_user_database(&ctx, "crm").await?;
+register_schema(&ctx, "crm", "public").await?;
 
 let mut cols = BTreeMap::new();
 cols.insert(
     "id".to_string(),
     ColumnDef { col_type: "int".to_string(), nullable: false },
 );
-register_user_tables(&ctx, "users", vec![cols]).await?;
+register_user_tables(&ctx, "crm", "public", "users", vec![cols]).await?;
 ```
 
 Then you can run queries like:

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,12 +57,13 @@ async fn run() -> anyhow::Result<()> {
     let (ctx, log) = get_base_session_context(Some(schema_path), default_catalog.clone(), default_schema.clone()).await?;
 
     register_user_database(&ctx, "pgtry").await?;
+    pg_catalog_helpers::register_schema(&ctx, "pgtry", "public").await?;
     use pg_catalog_helpers::ColumnDef;
     let mut c1 = BTreeMap::new();
     c1.insert("id".to_string(), ColumnDef { col_type: "int".to_string(), nullable: true });
     let mut c2 = BTreeMap::new();
     c2.insert("name".to_string(), ColumnDef { col_type: "text".to_string(), nullable: true });
-    pg_catalog_helpers::register_user_tables(&ctx, "users", vec![c1, c2]).await?;
+    pg_catalog_helpers::register_user_tables(&ctx, "pgtry", "public", "users", vec![c1, c2]).await?;
 
     start_server(
         Arc::new(ctx),


### PR DESCRIPTION
## Summary
- make `register_user_database` insert the provided name
- add `register_schema` to create schema entries
- associate registered tables with their schema and require schema name
- update main example and README
- expand tests for new functions

## Testing
- `cargo test --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851b20d8524832fb4a93256265f2c6f
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added utilities to register schemas and associate tables with schemas and databases, making schema management more flexible and explicit.

- **New Features**
  - Added `register_schema` to create schema entries.
  - Updated `register_user_database` to insert the provided database name.
  - Updated `register_user_tables` to require schema and database names and link tables to schemas.
  - Expanded tests and updated the README and main example.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README example to show explicit registration of schemas and tables within user databases, reflecting recent API changes.

- **New Features**
  - Added support for registering schemas within user databases.
  - Improved table registration to specify both database and schema, allowing for more precise organization.

- **Bug Fixes**
  - Ensured tables are correctly associated with their registered schemas.

- **Tests**
  - Enhanced and expanded tests to verify schema and database registration functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->