### PR TITLE
Update workflow to check catalog changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,12 +72,22 @@ jobs:
           name: tarpaulin-report
           path: cobertura.xml
 
+      - name: Check pg_catalog_data changes
+        id: catalog_changed
+        run: |
+          git fetch --depth=2 origin main
+          if git diff --quiet HEAD^ HEAD -- pg_catalog_data; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Zip schema files
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.catalog_changed.outputs.changed == 'true'
         run: zip -r postgres-schema-nightly.zip pg_catalog_data/pg_schema
 
       - name: Upload schema to release
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.catalog_changed.outputs.changed == 'true'
         uses: softprops/action-gh-release@v1
         with:
           tag_name: schema-nightly-${{ github.run_id }}


### PR DESCRIPTION
## Summary
- only upload catalog to release if `pg_catalog_data/` changed

## Testing
- `cargo test --all --verbose`
- `pytest -s tests`
- (example tests omitted due to environment constraints)


------
https://chatgpt.com/codex/tasks/task_e_68528c6da374832fbc629a05e20227ac