### PR TITLE
Add rewrite for lowercase utc timezone

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -37,6 +37,7 @@ use crate::replace::{
     rewrite_schema_qualified_custom_types,
     rewrite_schema_qualified_text,
     rewrite_schema_qualified_udtfs,
+    rewrite_time_zone_utc,
     strip_default_collate,
 };
 
@@ -273,6 +274,7 @@ pub fn print_params(params: &Vec<Option<Bytes>>) {
 pub fn rewrite_filters(sql: &str) -> datafusion::error::Result<(String, HashMap<String, String>)>{
     let sql = replace_set_command_with_namespace(&sql)?;
     let sql = strip_default_collate(&sql)?;
+    let sql = rewrite_time_zone_utc(&sql)?;
     let sql = rewrite_regoper_cast(&sql)?;
     let sql = rewrite_regoperator_cast(&sql)?;
     let sql = rewrite_regprocedure_cast(&sql)?;

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -609,3 +609,12 @@ def test_capture_option(tmp_path):
     assert data[1]["parameters"] == [11]
     assert data[2]["success"] is False
 
+
+def test_postmaster_time_zone_lowercase(server):
+    with psycopg.connect(CONN_STR) as conn:
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT round(EXTRACT(EPOCH FROM pg_postmaster_start_time() AT TIME ZONE 'utc')) AS startup_time"
+        )
+        row = cur.fetchone()
+        assert isinstance(row[0], int)


### PR DESCRIPTION
## Summary
- rewrite `AT TIME ZONE 'utc'` to uppercase `UTC`
- include the new rewrite in session filters
- add regression tests for this rewrite
- test query using lowercase `utc`

## Testing
- `pytest -k postmaster_time_zone_lowercase -q` *(fails: connection refused)*
- `cargo test --lib` *(fails during compilation)*

------
https://chatgpt.com/codex/tasks/task_e_685a78d1e350832f8ab1d4eff5fbfeed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved handling of SQL queries using the UTC time zone by automatically converting lowercase 'utc' to uppercase 'UTC' for consistency.
- **Tests**
	- Added a functional test to verify correct processing of SQL queries with lowercase 'utc' in time zone expressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->