### PR TITLE
format: format rust code and add ci check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-          profile: minimal
           override: true
 
       - name: Cache
@@ -28,6 +27,9 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Rust format check
+        run: cargo fmt --check
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -41,7 +43,7 @@ jobs:
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
           restore-keys: |
             ${{ runner.os }}-pip-
-  
+
       - name: Install Python dependencies
         run: pip install -r requirements.txt
 
@@ -94,4 +96,3 @@ jobs:
           name: postgres-schema-nightly
           prerelease: true
           files: postgres-schema-nightly.zip
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,17 +2,17 @@
 // Exposes modules so the crate can be used as a library as well as a binary.
 
 pub mod clean_duplicate_columns;
-pub mod register_table;
-pub mod server;
 pub mod db_table;
-pub mod replace;
-pub mod session;
 pub mod logical_plan_rules;
-pub mod scalar_to_cte;
+pub mod pg_catalog_helpers;
+pub mod register_table;
+pub mod replace;
 pub mod replace_any_group_by;
 pub mod router;
+pub mod scalar_to_cte;
+pub mod server;
+pub mod session;
 pub mod user_functions;
-pub mod pg_catalog_helpers;
 // Re-export all public functions from pg_catalog_helpers for convenience.
 pub use pg_catalog_helpers::*;
 // Re-export commonly used functions at crate root for convenience.

--- a/src/logical_plan_rules.rs
+++ b/src/logical_plan_rules.rs
@@ -3,10 +3,7 @@
 // Added to better mimic PostgreSQL planning.
 
 use datafusion::{
-    common::{
-        tree_node::Transformed,
-        Result,
-    },
+    common::{tree_node::Transformed, Result},
     logical_expr::{Expr, LogicalPlan},
     optimizer::{ApplyOrder, OptimizerConfig, OptimizerRule},
 };
@@ -15,10 +12,14 @@ use datafusion::{
 pub struct StripPgGetOne;
 
 impl OptimizerRule for StripPgGetOne {
-    fn name(&self) -> &str { "strip_pg_get_one" }
+    fn name(&self) -> &str {
+        "strip_pg_get_one"
+    }
 
     // ask the optimiser framework to call us bottom‑up on every node
-    fn apply_order(&self) -> Option<ApplyOrder> { Some(ApplyOrder::BottomUp) }
+    fn apply_order(&self) -> Option<ApplyOrder> {
+        Some(ApplyOrder::BottomUp)
+    }
 
     fn rewrite(
         &self,
@@ -39,21 +40,22 @@ impl OptimizerRule for StripPgGetOne {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
-    use crate::user_functions::{register_pg_get_one, register_scalar_regclass_oid, RegClassOidFunc};
+    use crate::user_functions::{
+        register_pg_get_one, register_scalar_regclass_oid, RegClassOidFunc,
+    };
 
     use super::*;
     use arrow::array::{Int64Array, StringArray};
     use arrow::datatypes::{DataType, Field, Schema};
     use arrow::record_batch::RecordBatch;
     use datafusion::catalog::memory::{MemoryCatalogProvider, MemorySchemaProvider};
+    use datafusion::catalog::{CatalogProvider, SchemaProvider};
     use datafusion::datasource::MemTable;
     use datafusion::error::Result;
     use datafusion::prelude::*;
     use std::sync::Arc;
-    use datafusion::catalog::{CatalogProvider, SchemaProvider};
 
     /* TODO:
 
@@ -67,7 +69,6 @@ mod tests {
 
 
      */
-
 
     async fn make_ctx() -> Result<SessionContext> {
         let mut config = datafusion::execution::context::SessionConfig::new()
@@ -101,7 +102,6 @@ mod tests {
         Ok(ctx)
     }
 
-
     #[tokio::test]
     async fn test_pggetone_correlated_subquery() -> Result<()> {
         use crate::logical_plan_rules::StripPgGetOne;
@@ -129,5 +129,4 @@ mod tests {
         assert_eq!(col.value(0), "pg_constraint");
         Ok(())
     }
-
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,13 @@
 // Entry point for the pg_catalog compatibility server.
 // Parses CLI arguments, builds a SessionContext and starts the pgwire server.
 // Provides a simple way to run the DataFusion-backed PostgreSQL emulator.
+use datafusion_pg_catalog::{pg_catalog_helpers, register_user_database};
 use std::collections::BTreeMap;
 use std::env;
 use std::sync::Arc;
-use datafusion_pg_catalog::{pg_catalog_helpers, register_user_database};
 // use arrow::util::pretty;
-use datafusion_pg_catalog::{server::start_server};
+use datafusion_pg_catalog::server::start_server;
 use datafusion_pg_catalog::session::get_base_session_context;
-
 
 async fn run() -> anyhow::Result<()> {
     let args: Vec<String> = env::args().collect();
@@ -22,25 +21,29 @@ async fn run() -> anyhow::Result<()> {
 
     let schema_path = &args[1];
 
-    let default_catalog = args.iter()
+    let default_catalog = args
+        .iter()
         .position(|x| x == "--default-catalog")
         .and_then(|i| args.get(i + 1))
         .unwrap_or(&"datafusion".to_string())
         .clone();
 
-    let default_schema = args.iter()
+    let default_schema = args
+        .iter()
         .position(|x| x == "--default-schema")
         .and_then(|i| args.get(i + 1))
         .unwrap_or(&"public".to_string())
         .clone();
 
-    let host = args.iter()
+    let host = args
+        .iter()
         .position(|x| x == "--host")
         .and_then(|i| args.get(i + 1))
         .unwrap_or(&"127.0.0.1".to_string())
         .clone();
 
-    let port = args.iter()
+    let port = args
+        .iter()
         .position(|x| x == "--port")
         .and_then(|i| args.get(i + 1))
         .unwrap_or(&"5433".to_string())
@@ -48,22 +51,41 @@ async fn run() -> anyhow::Result<()> {
 
     let address = format!("{}:{}", host, port);
 
-    let capture_file = args.iter()
+    let capture_file = args
+        .iter()
         .position(|x| x == "--capture")
         .and_then(|i| args.get(i + 1))
         .cloned();
 
-
-    let (ctx, log) = get_base_session_context(Some(schema_path), default_catalog.clone(), default_schema.clone(), None).await?;
+    let (ctx, log) = get_base_session_context(
+        Some(schema_path),
+        default_catalog.clone(),
+        default_schema.clone(),
+        None,
+    )
+    .await?;
 
     register_user_database(&ctx, "pgtry").await?;
     pg_catalog_helpers::register_schema(&ctx, "pgtry", "public").await?;
     use pg_catalog_helpers::ColumnDef;
     let mut c1 = BTreeMap::new();
-    c1.insert("id".to_string(), ColumnDef { col_type: "int".to_string(), nullable: true });
+    c1.insert(
+        "id".to_string(),
+        ColumnDef {
+            col_type: "int".to_string(),
+            nullable: true,
+        },
+    );
     let mut c2 = BTreeMap::new();
-    c2.insert("name".to_string(), ColumnDef { col_type: "text".to_string(), nullable: true });
-    pg_catalog_helpers::register_user_tables(&ctx, "pgtry", "public", "users", vec![c1, c2]).await?;
+    c2.insert(
+        "name".to_string(),
+        ColumnDef {
+            col_type: "text".to_string(),
+            nullable: true,
+        },
+    );
+    pg_catalog_helpers::register_user_tables(&ctx, "pgtry", "public", "users", vec![c1, c2])
+        .await?;
 
     start_server(
         Arc::new(ctx),
@@ -77,7 +99,6 @@ async fn run() -> anyhow::Result<()> {
     Ok(())
 }
 
-
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     env_logger::init();
@@ -90,16 +111,16 @@ async fn main() -> anyhow::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use datafusion_pg_catalog::router::dispatch_query;
-    use datafusion::execution::context::SessionContext;
-    use std::sync::Arc;
     use arrow::datatypes::Schema;
+    use datafusion::execution::context::SessionContext;
+    use datafusion_pg_catalog::router::dispatch_query;
+    use std::sync::Arc;
 
     #[tokio::test]
     async fn test_dispatch_in_main() -> anyhow::Result<()> {
         let ctx = SessionContext::new();
-        dispatch_query(&ctx, "SELECT 1", None, None, |_c, _q, _p, _t| {
-            async { Ok((Vec::new(), Arc::new(Schema::empty()))) }
+        dispatch_query(&ctx, "SELECT 1", None, None, |_c, _q, _p, _t| async {
+            Ok((Vec::new(), Arc::new(Schema::empty())))
         })
         .await?;
         Ok(())

--- a/src/register_table.rs
+++ b/src/register_table.rs
@@ -2,15 +2,16 @@ use std::sync::Arc;
 
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
-use datafusion::catalog::{CatalogProvider, MemoryCatalogProvider, MemorySchemaProvider, SchemaProvider};
+use datafusion::catalog::{
+    CatalogProvider, MemoryCatalogProvider, MemorySchemaProvider, SchemaProvider,
+};
 use datafusion::datasource::MemTable;
-use datafusion::execution::context::SessionContext;
 use datafusion::error::Result;
-
+use datafusion::execution::context::SessionContext;
 
 /// Register a new datafusion memtable in the given catalog and schema.
 /// Creates the catalog or schema if it does not exist.
-/// Example: 
+/// Example:
 /// ```text
 ///  use datafusion_pg_catalog::register_table::register_table;
 ///  register_table(
@@ -102,10 +103,7 @@ mod tests {
         assert_eq!(count, 0);
 
         // verify nullability settings
-        let table = schema
-            .table("mytable")
-            .await?
-            .expect("table should exist");
+        let table = schema.table("mytable").await?.expect("table should exist");
         let schema = table.schema();
         let fields = schema.fields();
         assert!(!fields[0].is_nullable());

--- a/src/replace_any_group_by.rs
+++ b/src/replace_any_group_by.rs
@@ -82,7 +82,6 @@ pub fn rewrite_group_by_for_any(sql: &str) -> String {
         .join("; ")
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/session.rs
+++ b/src/session.rs
@@ -2,99 +2,66 @@
 // Loads YAML schemas into MemTables, registers UDFs and executes rewritten queries using DataFusion.
 // Separated to encapsulate DataFusion setup and query execution behaviour.
 
-use arrow::array::{Int32Array, ArrayRef};
+use arrow::array::{ArrayRef, Int32Array};
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use arrow::record_batch::RecordBatch;
 use datafusion::catalog::memory::{MemoryCatalogProvider, MemorySchemaProvider};
 use datafusion::error::DataFusionError;
 use datafusion::execution::context::SessionContext;
-use arrow::record_batch::RecordBatch;
 use serde::Deserialize;
 use serde_yaml;
 
+use crate::clean_duplicate_columns::alias_all_columns;
+use crate::replace::{
+    alias_subquery_tables, regclass_udfs, replace_regclass, replace_set_command_with_namespace,
+    rewrite_array_subquery, rewrite_available_updates, rewrite_brace_array_literal,
+    rewrite_char_cast, rewrite_name_cast, rewrite_oid_cast, rewrite_oidvector_any,
+    rewrite_oidvector_unnest, rewrite_pg_custom_operator, rewrite_regoper_cast,
+    rewrite_regoperator_cast, rewrite_regproc_cast, rewrite_regprocedure_cast,
+    rewrite_regtype_cast, rewrite_schema_qualified_custom_types, rewrite_schema_qualified_text,
+    rewrite_schema_qualified_udtfs, rewrite_time_zone_utc, rewrite_tuple_equality,
+    rewrite_xid_cast, strip_default_collate,
+};
+use pgwire::api::Type;
 use std::collections::{BTreeMap, HashMap};
 use std::fs;
+use std::io::{Cursor, Read};
 use std::path::Path;
-use std::io::{Read, Cursor};
 use std::ptr::null;
 use std::sync::{Arc, Mutex};
 use zip::ZipArchive;
-use pgwire::api::Type;
-use crate::clean_duplicate_columns::alias_all_columns;
-use crate::replace::{
-    regclass_udfs,
-    replace_regclass,
-    replace_set_command_with_namespace,
-    rewrite_array_subquery,
-    rewrite_brace_array_literal,
-    rewrite_pg_custom_operator,
-    rewrite_regtype_cast, rewrite_oid_cast, rewrite_char_cast,
-    rewrite_xid_cast, rewrite_name_cast,
-    rewrite_regoper_cast, rewrite_regoperator_cast, rewrite_regprocedure_cast, rewrite_regproc_cast,
-    rewrite_available_updates,
-    rewrite_oidvector_unnest,
-    rewrite_oidvector_any,
-    rewrite_tuple_equality,
-    alias_subquery_tables,
-    rewrite_schema_qualified_custom_types,
-    rewrite_schema_qualified_text,
-    rewrite_schema_qualified_udtfs,
-    rewrite_time_zone_utc,
-    strip_default_collate,
-};
 
 use crate::user_functions::{
-    register_array_agg,
-    register_current_schema,
-    register_current_schemas,
-    register_pg_get_array,
-    register_oidvector_to_array,
-    register_pg_get_function_arguments,
-    register_pg_get_function_result,
-    register_pg_get_function_sqlbody,
-    register_pg_get_indexdef,
-    register_pg_get_triggerdef,
-    register_pg_get_ruledef,
-    register_pg_get_one,
-    register_pg_get_statisticsobjdef_columns,
-    register_pg_get_viewdef,
-    register_pg_get_keywords,
-    register_pg_available_extension_versions,
-    register_pg_postmaster_start_time,
-    register_pg_relation_is_publishable,
-    register_has_database_privilege,
-    register_has_schema_privilege,
-    register_pg_relation_size,
-    register_pg_total_relation_size,
-    register_quote_ident,
-    register_scalar_array_to_string,
-    register_scalar_format_type,
-    register_scalar_pg_age,
-    register_scalar_pg_encoding_to_char,
-    register_scalar_pg_get_expr,
-    register_scalar_pg_get_partkeydef,
-    register_scalar_pg_get_userbyid,
-    register_scalar_pg_is_in_recovery,
-    register_scalar_pg_table_is_visible,
-    register_scalar_pg_tablespace_location,
-    register_scalar_regclass_oid,
-    register_scalar_txid_current,
-    register_encode,
-    register_upper,
+    register_array_agg, register_current_schema, register_current_schemas, register_encode,
+    register_has_database_privilege, register_has_schema_privilege, register_oidvector_to_array,
+    register_pg_available_extension_versions, register_pg_get_array,
+    register_pg_get_function_arguments, register_pg_get_function_result,
+    register_pg_get_function_sqlbody, register_pg_get_indexdef, register_pg_get_keywords,
+    register_pg_get_one, register_pg_get_ruledef, register_pg_get_statisticsobjdef_columns,
+    register_pg_get_triggerdef, register_pg_get_viewdef, register_pg_postmaster_start_time,
+    register_pg_relation_is_publishable, register_pg_relation_size,
+    register_pg_total_relation_size, register_quote_ident, register_scalar_array_to_string,
+    register_scalar_format_type, register_scalar_pg_age, register_scalar_pg_encoding_to_char,
+    register_scalar_pg_get_expr, register_scalar_pg_get_partkeydef,
+    register_scalar_pg_get_userbyid, register_scalar_pg_is_in_recovery,
+    register_scalar_pg_table_is_visible, register_scalar_pg_tablespace_location,
+    register_scalar_regclass_oid, register_scalar_txid_current, register_translate, register_upper,
     register_version_fn,
-    register_translate,
 };
-
 
 use crate::scalar_to_cte::rewrite_subquery_as_cte;
 use bytes::Bytes;
 
+use datafusion::common::{config::ConfigEntry, config_err};
 use datafusion::scalar::ScalarValue;
-use datafusion::common::{config_err, config::ConfigEntry};
 
-static SCHEMA_ZIP: &[u8] = include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/pg_catalog_data/postgres-schema-nightly.zip"));
-use datafusion::common::config::{ConfigExtension, ExtensionOptions};
+static SCHEMA_ZIP: &[u8] = include_bytes!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/pg_catalog_data/postgres-schema-nightly.zip"
+));
 use crate::db_table::{map_pg_type, ObservableMemTable, ScanTrace};
 use crate::replace_any_group_by::rewrite_group_by_for_any;
+use datafusion::common::config::{ConfigExtension, ExtensionOptions};
 use df_subquery_udf::rewrite_query;
 
 #[derive(Clone, Debug)]
@@ -114,18 +81,22 @@ impl Default for ClientOpts {
     }
 }
 
-
 impl ConfigExtension for ClientOpts {
     const PREFIX: &'static str = "pg_catalog";
 }
 
 impl ExtensionOptions for ClientOpts {
-    fn as_any(&self) -> &dyn std::any::Any { self }
-    fn as_any_mut(&mut self) -> &mut dyn std::any::Any { self }
-    fn cloned(&self) -> Box<dyn ExtensionOptions> { Box::new(self.clone()) }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+    fn cloned(&self) -> Box<dyn ExtensionOptions> {
+        Box::new(self.clone())
+    }
 
     fn set(&mut self, key: &str, value: &str) -> datafusion::error::Result<()> {
-        
         log::debug!("set key {:?}", key);
         match key {
             "application_name" => {
@@ -141,9 +112,7 @@ impl ExtensionOptions for ClientOpts {
                 self.search_path = value.to_string();
                 Ok(())
             }
-            "extra_float_digits" => {
-                Ok(())
-            }
+            "extra_float_digits" => Ok(()),
             _ => config_err!("unknown key {key}"),
         }
     }
@@ -167,9 +136,7 @@ impl ExtensionOptions for ClientOpts {
             },
         ]
     }
-
 }
-
 
 #[derive(Debug, Deserialize)]
 struct TableDef {
@@ -184,8 +151,6 @@ struct TableDef {
 #[derive(Debug, Deserialize)]
 struct YamlSchema(HashMap<String, HashMap<String, HashMap<String, TableDef>>>);
 
-
-
 fn rename_columns(batch: &RecordBatch, name_map: &HashMap<String, String>) -> RecordBatch {
     let new_fields = batch
         .schema()
@@ -196,7 +161,11 @@ fn rename_columns(batch: &RecordBatch, name_map: &HashMap<String, String>) -> Re
                 .get(old_field.name())
                 .map(|s| s.as_str())
                 .unwrap_or_else(|| old_field.name().as_str());
-            Field::new(new_name, old_field.data_type().clone(), old_field.is_nullable())
+            Field::new(
+                new_name,
+                old_field.data_type().clone(),
+                old_field.is_nullable(),
+            )
         })
         .collect::<Vec<_>>();
 
@@ -243,26 +212,27 @@ fn remove_virtual_system_columns(
     (new_batches, new_schema)
 }
 
-
-
 pub fn print_params(params: &Vec<Option<Bytes>>) {
     for (i, param) in params.iter().enumerate() {
         match param {
-            Some(bytes) => {
-                match bytes.len() {
-                    4 => {
-                        let v = u32::from_be_bytes(bytes[..4].try_into().unwrap());
-                        log::debug!("param[{}] as u32: {}", i, v);
-                    }
-                    8 => {
-                        let v = u64::from_be_bytes(bytes[..8].try_into().unwrap());
-                        log::debug!("param[{}] as u64: {}", i, v);
-                    }
-                    _ => {
-                        log::debug!("param[{}] raw bytes ({} bytes): {:?}", i, bytes.len(), bytes);
-                    }
+            Some(bytes) => match bytes.len() {
+                4 => {
+                    let v = u32::from_be_bytes(bytes[..4].try_into().unwrap());
+                    log::debug!("param[{}] as u32: {}", i, v);
                 }
-            }
+                8 => {
+                    let v = u64::from_be_bytes(bytes[..8].try_into().unwrap());
+                    log::debug!("param[{}] as u64: {}", i, v);
+                }
+                _ => {
+                    log::debug!(
+                        "param[{}] raw bytes ({} bytes): {:?}",
+                        i,
+                        bytes.len(),
+                        bytes
+                    );
+                }
+            },
             None => {
                 log::debug!("param[{}] is NULL", i);
             }
@@ -272,7 +242,7 @@ pub fn print_params(params: &Vec<Option<Bytes>>) {
 
 /// Run the input SQL through all available rewrite passes and return
 /// the transformed query together with any alias mappings produced.
-pub fn rewrite_filters(sql: &str) -> datafusion::error::Result<(String, HashMap<String, String>)>{
+pub fn rewrite_filters(sql: &str) -> datafusion::error::Result<(String, HashMap<String, String>)> {
     let sql = replace_set_command_with_namespace(&sql)?;
     let sql = strip_default_collate(&sql)?;
     let sql = rewrite_time_zone_utc(&sql)?;
@@ -303,9 +273,8 @@ pub fn rewrite_filters(sql: &str) -> datafusion::error::Result<(String, HashMap<
     log::debug!("before group by {}", sql);
     let sql = rewrite_group_by_for_any(&sql);
 
-    return Ok((sql, aliases))
+    return Ok((sql, aliases));
 }
-
 
 pub async fn execute_sql_inner(
     ctx: &SessionContext,
@@ -313,9 +282,8 @@ pub async fn execute_sql_inner(
     vec: Option<Vec<Option<Bytes>>>,
     vec0: Option<Vec<Type>>,
 ) -> datafusion::error::Result<(Vec<RecordBatch>, Arc<Schema>)> {
-
     log::debug!("input sql {:?}", sql);
-    
+
     let (sql, aliases) = rewrite_filters(&sql)?;
 
     let (sql, temp_udfs) = rewrite_query(&sql, &mut ctx.clone()).await?;
@@ -403,16 +371,12 @@ pub async fn execute_sql_inner(
 
     let (results, schema) = remove_virtual_system_columns(&sql, results, schema);
 
-
     // after the execution of the query we do a cleanup for added udfs
     for name in temp_udfs {
         ctx.deregister_udf(&name);
     }
 
-
     Ok((results, schema))
-
-
 }
 
 pub async fn execute_sql(
@@ -433,7 +397,6 @@ pub async fn execute_sql(
     }
 }
 
-
 fn parse_schema(
     schema_path: Option<&str>,
 ) -> HashMap<String, HashMap<String, HashMap<String, (SchemaRef, Vec<RecordBatch>)>>> {
@@ -449,7 +412,10 @@ fn parse_schema(
         } else if path.is_dir() {
             parse_schema_dir(schema_path)
         } else {
-            panic!("schema_path {} is neither a file nor a directory", schema_path);
+            panic!(
+                "schema_path {} is neither a file nor a directory",
+                schema_path
+            );
         }
     } else {
         parse_schema_zip_bytes(SCHEMA_ZIP)
@@ -509,17 +475,26 @@ fn parse_schema_contents(
     contents: &str,
 ) -> HashMap<String, HashMap<String, HashMap<String, (SchemaRef, Vec<RecordBatch>)>>> {
     let parsed: YamlSchema = serde_yaml::from_str(contents).expect("Invalid YAML");
-    parsed.0.into_iter()
+    parsed
+        .0
+        .into_iter()
         .map(|(catalog, schemas)| {
-            let schemas = schemas.into_iter().map(|(schema, tables)| {
-                let tables = tables.into_iter().map(|(table, def)| {
-                    let (schema_ref, batches) = build_table(def);
-                    (table, (schema_ref, batches))
-                }).collect();
-                (schema, tables)
-            }).collect();
+            let schemas = schemas
+                .into_iter()
+                .map(|(schema, tables)| {
+                    let tables = tables
+                        .into_iter()
+                        .map(|(table, def)| {
+                            let (schema_ref, batches) = build_table(def);
+                            (table, (schema_ref, batches))
+                        })
+                        .collect();
+                    (schema, tables)
+                })
+                .collect();
             (catalog, schemas)
-        }).collect()
+        })
+        .collect()
 }
 
 fn parse_schema_dir(
@@ -531,8 +506,6 @@ fn parse_schema_dir(
         let path = entry.expect("Invalid dir entry").path();
         if path.extension().and_then(|s| s.to_str()) == Some("yaml") {
             let mut partial = parse_schema_file(path.to_str().unwrap());
-
-
 
             merge_schema_maps(&mut all, partial);
         }
@@ -576,34 +549,41 @@ fn build_table(def: TableDef) -> (SchemaRef, Vec<RecordBatch>) {
         let mut cols: Vec<Vec<serde_json::Value>> = vec![vec![]; fields.len()];
         for row in rows {
             for (i, field) in fields.iter().enumerate() {
-                cols[i].push(row.get(field.name()).cloned().unwrap_or(serde_json::Value::Null));
+                cols[i].push(
+                    row.get(field.name())
+                        .cloned()
+                        .unwrap_or(serde_json::Value::Null),
+                );
             }
         }
 
-        let arrays = fields.iter().zip(cols.into_iter())
+        let arrays = fields
+            .iter()
+            .zip(cols.into_iter())
             .map(|(field, col_data)| {
                 use arrow::array::*;
                 use arrow::datatypes::DataType;
                 let array: ArrayRef = match field.data_type() {
                     DataType::Utf8 => Arc::new(StringArray::from(
-                        col_data.into_iter()
+                        col_data
+                            .into_iter()
                             .map(|v| v.as_str().map(|s| s.to_string()))
-                            .collect::<Vec<_>>()
+                            .collect::<Vec<_>>(),
                     )),
                     DataType::Int32 => Arc::new(Int32Array::from(
-                        col_data.into_iter()
+                        col_data
+                            .into_iter()
                             .map(|v| v.as_i64().map(|i| i as i32))
-                            .collect::<Vec<_>>()
+                            .collect::<Vec<_>>(),
                     )),
                     DataType::Int64 => Arc::new(Int64Array::from(
-                        col_data.into_iter()
-                            .map(|v| v.as_i64())
-                            .collect::<Vec<_>>()
+                        col_data.into_iter().map(|v| v.as_i64()).collect::<Vec<_>>(),
                     )),
                     DataType::Boolean => Arc::new(BooleanArray::from(
-                        col_data.into_iter()
+                        col_data
+                            .into_iter()
                             .map(|v| v.as_bool())
-                            .collect::<Vec<_>>()
+                            .collect::<Vec<_>>(),
                     )),
                     DataType::Binary => {
                         let mut builder = BinaryBuilder::new();
@@ -614,7 +594,7 @@ fn build_table(def: TableDef) -> (SchemaRef, Vec<RecordBatch>) {
                             }
                         }
                         Arc::new(builder.finish())
-                    },
+                    }
                     DataType::List(inner) if inner.data_type() == &DataType::Utf8 => {
                         let mut builder = ListBuilder::new(StringBuilder::new());
                         for v in col_data {
@@ -622,7 +602,7 @@ fn build_table(def: TableDef) -> (SchemaRef, Vec<RecordBatch>) {
                                 for item in items {
                                     match item.as_str() {
                                         Some(s) => builder.values().append_value(s),
-                                        None    => builder.values().append_null(),
+                                        None => builder.values().append_null(),
                                     }
                                 }
                                 builder.append(true);
@@ -634,7 +614,7 @@ fn build_table(def: TableDef) -> (SchemaRef, Vec<RecordBatch>) {
                             }
                         }
                         Arc::new(builder.finish())
-                    },
+                    }
                     DataType::List(inner) if inner.data_type() == &DataType::Int64 => {
                         let mut builder = ListBuilder::new(Int64Builder::new());
                         for v in col_data {
@@ -661,7 +641,7 @@ fn build_table(def: TableDef) -> (SchemaRef, Vec<RecordBatch>) {
                             }
                         }
                         Arc::new(builder.finish())
-                    },
+                    }
                     DataType::List(inner) if inner.data_type() == &DataType::Int32 => {
                         let mut builder = ListBuilder::new(Int32Builder::new());
                         for v in col_data {
@@ -688,12 +668,13 @@ fn build_table(def: TableDef) -> (SchemaRef, Vec<RecordBatch>) {
                             }
                         }
                         Arc::new(builder.finish())
-                    },
+                    }
 
                     _ => Arc::new(StringArray::from(
-                        col_data.into_iter()
+                        col_data
+                            .into_iter()
                             .map(|v| Some(v.to_string()))
-                            .collect::<Vec<_>>()
+                            .collect::<Vec<_>>(),
                     )),
                 };
                 array
@@ -732,18 +713,22 @@ fn build_table(def: TableDef) -> (SchemaRef, Vec<RecordBatch>) {
     (Arc::new(Schema::new(fields)), record_batches)
 }
 
-
-fn register_catalogs_from_schemas(ctx:&SessionContext, schemas: HashMap<String, HashMap<String, HashMap<String, (Arc<Schema>, Vec<RecordBatch>)>>>, default_catalog:String, log: Arc<Mutex<Vec<ScanTrace>>>) -> datafusion::error::Result<&SessionContext, DataFusionError> {
-    for (catalog_name, schemas) in schemas {        
+fn register_catalogs_from_schemas(
+    ctx: &SessionContext,
+    schemas: HashMap<String, HashMap<String, HashMap<String, (Arc<Schema>, Vec<RecordBatch>)>>>,
+    default_catalog: String,
+    log: Arc<Mutex<Vec<ScanTrace>>>,
+) -> datafusion::error::Result<&SessionContext, DataFusionError> {
+    for (catalog_name, schemas) in schemas {
         // "public" is the *database* name we used in exports
-        // so we copy the schema/tables under that database to default_catalog/database  
+        // so we copy the schema/tables under that database to default_catalog/database
         let current_catalog = if catalog_name.clone() == "public" {
             default_catalog.to_string()
         } else {
             catalog_name.clone()
         };
 
-        let catalog_provider = if let Some(catalog_provider) = ctx.catalog(&current_catalog){
+        let catalog_provider = if let Some(catalog_provider) = ctx.catalog(&current_catalog) {
             catalog_provider
         } else {
             let catalog_provider = Arc::new(MemoryCatalogProvider::new());
@@ -752,27 +737,31 @@ fn register_catalogs_from_schemas(ctx:&SessionContext, schemas: HashMap<String, 
         };
 
         for (schema_name, tables) in schemas {
-
-            let schema_provider = if let Some(schema_provider) = catalog_provider.schema(&schema_name) {
-                schema_provider
-            } else {
-                Arc::new(MemorySchemaProvider::new())
-            };
+            let schema_provider =
+                if let Some(schema_provider) = catalog_provider.schema(&schema_name) {
+                    schema_provider
+                } else {
+                    Arc::new(MemorySchemaProvider::new())
+                };
 
             let _ = catalog_provider.register_schema(&schema_name, schema_provider.clone());
-            log::debug!("catalog/database: {:?} schema: {:?}", current_catalog, schema_name);
+            log::debug!(
+                "catalog/database: {:?} schema: {:?}",
+                current_catalog,
+                schema_name
+            );
 
             for (table, (schema_ref, batches)) in tables {
                 log::debug!("-- table {:?}", &table);
 
-                let wrapped = ObservableMemTable::new(table.clone(), schema_ref, log.clone(), batches);
+                let wrapped =
+                    ObservableMemTable::new(table.clone(), schema_ref, log.clone(), batches);
                 schema_provider.register_table(table, Arc::new(wrapped))?;
             }
         }
     }
     Ok(ctx)
 }
-
 
 fn default_current_schemas(ctx: &SessionContext) -> Vec<String> {
     let state = ctx.state();
@@ -786,16 +775,14 @@ fn default_current_schemas(ctx: &SessionContext) -> Vec<String> {
     vec!["pg_catalog".to_string(), user_schema]
 }
 
-pub async fn get_base_session_context(schema_path: Option<&str>, 
-        default_catalog:String, 
-        default_schema:String,
-        current_schemas_getter: Option<Arc<dyn Fn(&SessionContext) -> Vec<String> + Send + Sync>>,
-    ) -> datafusion::error::Result<(SessionContext, Arc<Mutex<Vec<ScanTrace>>>)> 
-    {
-
+pub async fn get_base_session_context(
+    schema_path: Option<&str>,
+    default_catalog: String,
+    default_schema: String,
+    current_schemas_getter: Option<Arc<dyn Fn(&SessionContext) -> Vec<String> + Send + Sync>>,
+) -> datafusion::error::Result<(SessionContext, Arc<Mutex<Vec<ScanTrace>>>)> {
     let _current_schemas_getter: Arc<dyn Fn(&SessionContext) -> Vec<String> + Send + Sync> =
         current_schemas_getter.unwrap_or_else(|| Arc::new(default_current_schemas));
-
 
     let log: Arc<Mutex<Vec<ScanTrace>>> = Arc::new(Mutex::new(Vec::new()));
 
@@ -814,12 +801,18 @@ pub async fn get_base_session_context(schema_path: Option<&str>,
         ctx.register_udf(f);
     }
 
-    ctx.register_udtf("regclass_oid", Arc::new(crate::user_functions::RegClassOidFunc));
+    ctx.register_udtf(
+        "regclass_oid",
+        Arc::new(crate::user_functions::RegClassOidFunc),
+    );
 
     register_scalar_regclass_oid(&ctx)?;
     register_scalar_pg_tablespace_location(&ctx)?;
     register_scalar_format_type(&ctx)?;
-    ctx.register_udtf("regclass_oid", Arc::new(crate::user_functions::RegClassOidFunc));
+    ctx.register_udtf(
+        "regclass_oid",
+        Arc::new(crate::user_functions::RegClassOidFunc),
+    );
 
     register_current_schema(&ctx, _current_schemas_getter.clone())?;
     register_current_schemas(&ctx, _current_schemas_getter.clone())?;
@@ -860,7 +853,6 @@ pub async fn get_base_session_context(schema_path: Option<&str>,
     register_upper(&ctx)?;
     register_version_fn(&ctx)?;
 
-
     let catalogs = ctx.catalog_names();
     log::info!("registered catalogs: {:?}", catalogs);
 
@@ -872,11 +864,11 @@ pub async fn get_base_session_context(schema_path: Option<&str>,
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tempfile::NamedTempFile;
-    use std::io::Write;
+    use arrow::array::ArrayRef;
     use arrow::array::{Int32Array, StringArray};
     use arrow::datatypes::DataType;
-    use arrow::array::{ArrayRef};
+    use std::io::Write;
+    use tempfile::NamedTempFile;
 
     #[test]
     fn test_parse_schema_file() {
@@ -914,11 +906,19 @@ public:
         let batch = &batches[0];
         assert_eq!(batch.num_rows(), 2);
 
-        let id_array = batch.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
+        let id_array = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
         assert_eq!(id_array.value(0), 1);
         assert_eq!(id_array.value(1), 2);
 
-        let name_array = batch.column(1).as_any().downcast_ref::<StringArray>().unwrap();
+        let name_array = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
         assert_eq!(name_array.value(0), "Alice");
         assert_eq!(name_array.value(1), "Bob");
     }
@@ -952,10 +952,9 @@ public:
         assert!(Arc::ptr_eq(batch.column(1), renamed.column(1)));
     }
 
-
     #[test]
     fn test_parse_schema_text_array() {
-        use arrow::array::{ListArray};
+        use arrow::array::ListArray;
         let yaml = r#"
 public:
   myschema:
@@ -979,13 +978,16 @@ public:
         assert!(matches!(field.data_type(), DataType::List(_)));
 
         let batch = &batches[0];
-        let list = batch.column(0).as_any().downcast_ref::<ListArray>().unwrap();
+        let list = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<ListArray>()
+            .unwrap();
         let binding = list.value(0);
         let inner = binding.as_any().downcast_ref::<StringArray>().unwrap();
         assert_eq!(inner.value(0), "x");
         assert_eq!(inner.value(1), "y");
     }
-
 
     #[test]
     fn test_rename_columns_partial() {
@@ -1039,18 +1041,24 @@ public:
         assert_eq!(out[0].num_columns(), 1);
 
         // when the result already only contains the system column, it should be preserved
-        let xmin_schema = Arc::new(Schema::new(vec![Field::new("xmin", DataType::Int32, false)]));
+        let xmin_schema = Arc::new(Schema::new(vec![Field::new(
+            "xmin",
+            DataType::Int32,
+            false,
+        )]));
         let xmin_batch = RecordBatch::try_new(
             xmin_schema.clone(),
             vec![Arc::new(Int32Array::from(vec![42])) as ArrayRef],
         )
         .unwrap();
 
-        let (out, out_schema) =
-            remove_virtual_system_columns("SELECT xmin FROM t", vec![xmin_batch.clone()], xmin_schema.clone());
+        let (out, out_schema) = remove_virtual_system_columns(
+            "SELECT xmin FROM t",
+            vec![xmin_batch.clone()],
+            xmin_schema.clone(),
+        );
         assert_eq!(out_schema.fields().len(), 1);
         assert_eq!(out_schema.field(0).name(), "xmin");
         assert_eq!(out[0].num_columns(), 1);
     }
 }
-

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -1,11 +1,11 @@
-use datafusion_pg_catalog::{dispatch_query, get_base_session_context, start_server};
-use datafusion::execution::context::SessionContext;
 use arrow::datatypes::Schema;
-use std::sync::{Arc, Mutex};
+use datafusion::execution::context::SessionContext;
+use datafusion_pg_catalog::{dispatch_query, get_base_session_context, start_server};
 use std::fs::File;
 use std::io::Read;
 use std::io::Write as IoWrite;
 use std::path::Path;
+use std::sync::{Arc, Mutex};
 use zip::write::FileOptions;
 use zip::ZipWriter;
 
@@ -37,19 +37,15 @@ async fn test_get_base_session_context_public() -> datafusion::error::Result<()>
         Some(zip_path.to_str().unwrap()),
         "pgtry".to_string(),
         "public".to_string(),
-        None
-    ).await?;
+        None,
+    )
+    .await?;
     Ok(())
 }
 
 #[tokio::test]
 async fn test_get_base_session_context_embedded() -> datafusion::error::Result<()> {
-    let _ = get_base_session_context(
-        None,
-        "pgtry".to_string(),
-        "public".to_string(),
-        None
-    ).await?;
+    let _ = get_base_session_context(None, "pgtry".to_string(), "public".to_string(), None).await?;
     Ok(())
 }
 
@@ -63,8 +59,12 @@ fn create_zip(path: &Path) {
             continue;
         }
         let mut contents = String::new();
-        File::open(&path).unwrap().read_to_string(&mut contents).unwrap();
-        zip.start_file(path.file_name().unwrap().to_str().unwrap(), options).unwrap();
+        File::open(&path)
+            .unwrap()
+            .read_to_string(&mut contents)
+            .unwrap();
+        zip.start_file(path.file_name().unwrap().to_str().unwrap(), options)
+            .unwrap();
         zip.write_all(contents.as_bytes()).unwrap();
     }
     zip.finish().unwrap();


### PR DESCRIPTION
First let's format all the code using `cargo fmt` and add a ci task, so we can be efficient on code contribution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved code formatting, readability, and consistency across multiple modules.
  * Reorganized and cleaned up import statements for better clarity.
  * Enforced Rust code formatting checks in the build process.
  * Made minor whitespace and stylistic adjustments throughout the codebase.

* **Tests**
  * Reformatted test code for improved readability and consistent style.

No functional changes or user-facing behavior were altered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->