### PR TITLE
register tables also to information_schema.tables

### DIFF
--- a/src/pg_catalog_helpers.rs
+++ b/src/pg_catalog_helpers.rs
@@ -24,6 +24,18 @@ fn map_type_to_oid(t: &str) -> i32 {
     }
 }
 
+fn normalize_data_type_name(t: &str) -> (String, String) {
+    let lower = t.to_lowercase();
+    match lower.as_str() {
+        "int" | "integer" | "int4" => ("integer".to_string(), "int4".to_string()),
+        "bigint" | "int8" => ("bigint".to_string(), "int8".to_string()),
+        "bool" | "boolean" => ("boolean".to_string(), "bool".to_string()),
+        s if s.starts_with("varchar") => ("character varying".to_string(), "varchar".to_string()),
+        "text" => ("text".to_string(), "text".to_string()),
+        _ => (lower.clone(), lower.clone()),
+    }
+}
+
 pub async fn register_user_database(ctx: &SessionContext, database_name: &str) -> DFResult<()> {
     // let oid = NEXT_OID.fetch_add(1, Ordering::SeqCst);
 
@@ -225,6 +237,62 @@ pub async fn register_user_tables(
         ctx.sql(&insert_sql).await?.collect().await?;
     }
 
+    // Insert columns into information_schema.columns
+    for (idx, col) in columns.iter().enumerate() {
+        let (col_name, def) = col.iter().next().unwrap();
+        let (data_type, udt_name) = normalize_data_type_name(&def.col_type);
+        let is_nullable = if def.nullable { "YES" } else { "NO" };
+
+        let exists_df = ctx
+            .sql(
+                "SELECT 1 FROM information_schema.columns \
+                 WHERE table_catalog=$cat AND table_schema=$sch AND table_name=$tbl AND column_name=$col",
+            )
+            .await?
+            .with_param_values(vec![
+                ("cat", ScalarValue::from(_database_name)),
+                ("sch", ScalarValue::from(schema_name)),
+                ("tbl", ScalarValue::from(table_name)),
+                ("col", ScalarValue::from(col_name.as_str())),
+            ])?;
+        if exists_df.count().await? == 0 {
+            let insert_sql = format!(
+                "INSERT INTO information_schema.columns \
+                 (table_catalog, table_schema, table_name, column_name, ordinal_position, \
+                  column_default, is_nullable, data_type, \
+                  character_maximum_length, character_octet_length, numeric_precision, \
+                  numeric_precision_radix, numeric_scale, datetime_precision, interval_type, \
+                  interval_precision, character_set_catalog, character_set_schema, character_set_name, \
+                  collation_catalog, collation_schema, collation_name, domain_catalog, domain_schema, domain_name, \
+                  udt_catalog, udt_schema, udt_name, scope_catalog, scope_schema, scope_name, \
+                  maximum_cardinality, dtd_identifier, is_self_referencing, is_identity, identity_generation, \
+                  identity_start, identity_increment, identity_maximum, identity_minimum, identity_cycle, \
+                  is_generated, generation_expression, is_updatable) \
+                 VALUES ('{}','{}','{}','{}',{}, \
+                         NULL,'{}','{}', \
+                         NULL,NULL,NULL, \
+                         NULL,NULL,NULL,NULL, \
+                         NULL,NULL,NULL,NULL, \
+                         NULL,NULL,NULL,NULL,NULL, \
+                         NULL,'{}','pg_catalog','{}',NULL,NULL,NULL, \
+                         NULL,'{}','NO','NO',NULL, \
+                         NULL,NULL,NULL,NULL,'NO', \
+                         'NEVER',NULL,'YES')",
+                _database_name.replace('\'', "''"),
+                schema_name.replace('\'', "''"),
+                table_name.replace('\'', "''"),
+                col_name.replace('\'', "''"),
+                idx + 1,
+                is_nullable,
+                data_type,
+                _database_name.replace('\'', "''"),
+                udt_name,
+                (idx + 1).to_string(),
+            );
+            ctx.sql(&insert_sql).await?.collect().await?;
+        }
+    }
+
     Ok(())
 }
 
@@ -375,6 +443,111 @@ mod tests {
         assert_eq!(typ, "BASE TABLE");
         assert_eq!(insertable, "YES");
         assert_eq!(is_typed, "NO");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_register_user_columns_information_schema() -> DFResult<()> {
+        let (ctx, _) = get_base_session_context(
+            Some("pg_catalog_data/pg_schema"),
+            "pgtry".to_string(),
+            "public".to_string(),
+            None,
+        )
+        .await?;
+
+        register_schema(&ctx, "pgtry", "myschema").await?;
+
+        let mut c1 = BTreeMap::new();
+        c1.insert(
+            "id".to_string(),
+            ColumnDef {
+                col_type: "int".to_string(),
+                nullable: true,
+            },
+        );
+        let mut c2 = BTreeMap::new();
+        c2.insert(
+            "name".to_string(),
+            ColumnDef {
+                col_type: "text".to_string(),
+                nullable: true,
+            },
+        );
+
+        register_user_tables(&ctx, "pgtry", "myschema", "contacts", vec![c1, c2]).await?;
+
+        let df = ctx
+            .sql(
+                "SELECT column_name, ordinal_position, data_type, is_nullable \
+                 FROM information_schema.columns \
+                 WHERE table_schema='myschema' AND table_name='contacts' \
+                 ORDER BY ordinal_position",
+            )
+            .await?;
+        let batches = df.collect().await?;
+        assert_eq!(batches[0].num_rows(), 2);
+
+        let col0 = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<arrow::array::StringArray>()
+            .unwrap()
+            .value(0);
+        let pos0 = batches[0]
+            .column(1)
+            .as_any()
+            .downcast_ref::<arrow::array::Int32Array>()
+            .unwrap()
+            .value(0);
+        let dt0 = batches[0]
+            .column(2)
+            .as_any()
+            .downcast_ref::<arrow::array::StringArray>()
+            .unwrap()
+            .value(0);
+        let nul0 = batches[0]
+            .column(3)
+            .as_any()
+            .downcast_ref::<arrow::array::StringArray>()
+            .unwrap()
+            .value(0);
+
+        let col1 = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<arrow::array::StringArray>()
+            .unwrap()
+            .value(1);
+        let pos1 = batches[0]
+            .column(1)
+            .as_any()
+            .downcast_ref::<arrow::array::Int32Array>()
+            .unwrap()
+            .value(1);
+        let dt1 = batches[0]
+            .column(2)
+            .as_any()
+            .downcast_ref::<arrow::array::StringArray>()
+            .unwrap()
+            .value(1);
+        let nul1 = batches[0]
+            .column(3)
+            .as_any()
+            .downcast_ref::<arrow::array::StringArray>()
+            .unwrap()
+            .value(1);
+
+        assert_eq!(col0, "id");
+        assert_eq!(pos0, 1);
+        assert_eq!(dt0, "integer");
+        assert_eq!(nul0, "YES");
+
+        assert_eq!(col1, "name");
+        assert_eq!(pos1, 2);
+        assert_eq!(dt1, "text");
+        assert_eq!(nul1, "YES");
+
         Ok(())
     }
 

--- a/src/pg_catalog_helpers.rs
+++ b/src/pg_catalog_helpers.rs
@@ -194,6 +194,37 @@ pub async fn register_user_tables(
         ctx.sql(&sql).await?.collect().await?;
     }
 
+    // Also reflect the newly registered table in information_schema.tables.
+    // Insert only if a matching row doesn't already exist (idempotent).
+    let exists_df = ctx
+        .sql(
+            "SELECT 1 FROM information_schema.tables \
+             WHERE table_catalog=$cat AND table_schema=$sch AND table_name=$tbl",
+        )
+        .await?
+        .with_param_values(vec![
+            ("cat", ScalarValue::from(_database_name)),
+            ("sch", ScalarValue::from(schema_name)),
+            ("tbl", ScalarValue::from(table_name)),
+        ])?;
+    if exists_df.count().await? == 0 {
+        let insert_sql = format!(
+            "INSERT INTO information_schema.tables \
+             (table_catalog, table_schema, table_name, table_type, \
+              self_referencing_column_name, reference_generation, \
+              user_defined_type_catalog, user_defined_type_schema, user_defined_type_name, \
+              is_insertable_into, is_typed, commit_action) \
+             VALUES ('{}','{}','{}','BASE TABLE', \
+                     NULL, NULL, \
+                     NULL, NULL, NULL, \
+                     'YES','NO', NULL)",
+            _database_name.replace('\'', "''"),
+            schema_name.replace('\'', "''"),
+            table_name.replace('\'', "''"),
+        );
+        ctx.sql(&insert_sql).await?.collect().await?;
+    }
+
     Ok(())
 }
 
@@ -259,6 +290,91 @@ mod tests {
             .await?;
         let batches = df.collect().await?;
         assert_eq!(batches[0].num_rows(), 2);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_register_user_tables_information_schema() -> DFResult<()> {
+        let (ctx, _) = get_base_session_context(
+            Some("pg_catalog_data/pg_schema"),
+            "pgtry".to_string(),
+            "public".to_string(),
+            None,
+        )
+        .await?;
+
+        register_schema(&ctx, "pgtry", "myschema").await?;
+
+        let mut c1 = BTreeMap::new();
+        c1.insert(
+            "id".to_string(),
+            ColumnDef {
+                col_type: "int".to_string(),
+                nullable: true,
+            },
+        );
+        let mut c2 = BTreeMap::new();
+        c2.insert(
+            "name".to_string(),
+            ColumnDef {
+                col_type: "text".to_string(),
+                nullable: true,
+            },
+        );
+
+        register_user_tables(&ctx, "pgtry", "myschema", "contacts", vec![c1, c2]).await?;
+
+        let df = ctx
+            .sql("SELECT table_catalog, table_schema, table_name, table_type, is_insertable_into, is_typed \
+                  FROM information_schema.tables \
+                  WHERE table_schema='myschema' AND table_name='contacts'")
+            .await?;
+        let batches = df.collect().await?;
+        assert_eq!(batches[0].num_rows(), 1);
+
+        let cat = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<arrow::array::StringArray>()
+            .unwrap()
+            .value(0);
+        let sch = batches[0]
+            .column(1)
+            .as_any()
+            .downcast_ref::<arrow::array::StringArray>()
+            .unwrap()
+            .value(0);
+        let name = batches[0]
+            .column(2)
+            .as_any()
+            .downcast_ref::<arrow::array::StringArray>()
+            .unwrap()
+            .value(0);
+        let typ = batches[0]
+            .column(3)
+            .as_any()
+            .downcast_ref::<arrow::array::StringArray>()
+            .unwrap()
+            .value(0);
+        let insertable = batches[0]
+            .column(4)
+            .as_any()
+            .downcast_ref::<arrow::array::StringArray>()
+            .unwrap()
+            .value(0);
+        let is_typed = batches[0]
+            .column(5)
+            .as_any()
+            .downcast_ref::<arrow::array::StringArray>()
+            .unwrap()
+            .value(0);
+
+        assert_eq!(cat, "pgtry");
+        assert_eq!(sch, "myschema");
+        assert_eq!(name, "contacts");
+        assert_eq!(typ, "BASE TABLE");
+        assert_eq!(insertable, "YES");
+        assert_eq!(is_typed, "NO");
         Ok(())
     }
 

--- a/src/scalar_to_cte.rs
+++ b/src/scalar_to_cte.rs
@@ -1468,6 +1468,7 @@ mod tests {
         "#;
 
         let sql = rewrite(q)?.sql;
+        // println!("result query {:?}", sql); 
 
         // scalar exposed
         assert!(sql.contains("__cte1.col"), "scalar alias 'col' missing");

--- a/src/scalar_to_cte.rs
+++ b/src/scalar_to_cte.rs
@@ -1468,7 +1468,7 @@ mod tests {
         "#;
 
         let sql = rewrite(q)?.sql;
-        // println!("result query {:?}", sql); 
+        // println!("result query {:?}", sql);
 
         // scalar exposed
         assert!(sql.contains("__cte1.col"), "scalar alias 'col' missing");

--- a/src/server.rs
+++ b/src/server.rs
@@ -698,9 +698,10 @@ impl SimpleQueryHandler for DatafusionBackend {
         C: ClientInfo + Unpin + Send + Sync,
     {
         log::debug!("query handler");
-
         let trimmed = query.trim();
         let lowercase = trimmed.to_lowercase();
+        // println!("query > {:?}", lowercase);
+
         if lowercase.starts_with("begin") {
             return Ok(vec![Response::Execution(Tag::new("BEGIN"))]);
         } else if lowercase.starts_with("commit") {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * information_schema now reflects user-registered tables and columns, including normalized data types and udt_names; registrations are idempotent (no duplicates).

* **Tests**
  * Added comprehensive tests verifying presence, metadata, and idempotent behavior for both tables and columns in information_schema.

* **Chores**
  * Minor commented debug print lines added in tests and server (no functional changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->