### PR TITLE
Upgrade pgwire to 0.33.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,6 +513,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
+name = "bcder"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f7c42c9913f68cf9390a225e81ad56a5c515347287eb98baa710090ca1de86d"
+dependencies = [
+ "bytes",
+ "smallvec",
+]
+
+[[package]]
 name = "bigdecimal"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -823,6 +833,12 @@ dependencies = [
  "unicode-segmentation",
  "unicode-width",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const-random"
@@ -1603,6 +1619,16 @@ dependencies = [
  "tokio",
  "uuid",
  "zip",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "zeroize",
 ]
 
 [[package]]
@@ -2475,9 +2501,9 @@ dependencies = [
 
 [[package]]
 name = "md5"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
 
 [[package]]
 name = "memchr"
@@ -2626,7 +2652,7 @@ dependencies = [
  "itertools 0.14.0",
  "parking_lot",
  "percent-encoding",
- "thiserror 2.0.12",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
  "url",
@@ -2752,6 +2778,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38af38e8470ac9dee3ce1bae1af9c1671fffc44ddfd8bd1d0a3445bf349a8ef3"
+dependencies = [
+ "base64",
+ "serde",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2769,12 +2805,13 @@ dependencies = [
 
 [[package]]
 name = "pgwire"
-version = "0.28.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c84e671791f3a354f265e55e400be8bb4b6262c1ec04fac4289e710ccf22ab43"
+checksum = "f58d371668e6151da16be31308989058156c01257277ea8af0f97524e87cfa31"
 dependencies = [
  "async-trait",
  "aws-lc-rs",
+ "base64",
  "bytes",
  "chrono",
  "derive-new",
@@ -2783,12 +2820,15 @@ dependencies = [
  "lazy-regex",
  "md5",
  "postgres-types",
- "rand 0.8.5",
+ "rand 0.9.1",
  "rust_decimal",
- "thiserror 2.0.12",
+ "rustls-pki-types",
+ "stringprep",
+ "thiserror 2.0.17",
  "tokio",
  "tokio-rustls",
  "tokio-util",
+ "x509-certificate",
 ]
 
 [[package]]
@@ -3407,6 +3447,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3447,6 +3496,16 @@ checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -3595,11 +3654,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl 2.0.17",
 ]
 
 [[package]]
@@ -3615,9 +3674,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4229,6 +4288,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "x509-certificate"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca9eb9a0c822c67129d5b8fcc2806c6bc4f50496b420825069a440669bcfbf7f"
+dependencies = [
+ "bcder",
+ "bytes",
+ "chrono",
+ "der",
+ "hex",
+ "pem",
+ "ring",
+ "signature",
+ "spki",
+ "thiserror 2.0.17",
+ "zeroize",
+]
+
+[[package]]
 name = "xz2"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4327,6 +4405,20 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
 
 [[package]]
 name = "zerovec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ serde_yaml = "0.9"
 regex = "1"
 async-trait = "0.1"
 uuid = { version = "1.16.0", features = ["v4"] }
-pgwire = "0.28.0"
+pgwire = "0.33.0"
 futures = "0.3.31"
 anyhow = "1.0.98"
 bytes = "1.10.1"

--- a/src/server.rs
+++ b/src/server.rs
@@ -10,7 +10,9 @@ use bytes::Bytes;
 use futures::sink::Sink;
 use futures::{stream, Stream};
 use pgwire::api::auth::md5pass::{hash_md5_password, Md5PasswordAuthStartupHandler};
-use pgwire::api::auth::{AuthSource, DefaultServerParameterProvider, LoginInfo, Password, StartupHandler};
+use pgwire::api::auth::{
+    AuthSource, DefaultServerParameterProvider, LoginInfo, Password, StartupHandler,
+};
 use pgwire::api::copy::CopyHandler;
 use pgwire::api::portal::{Format, Portal};
 use pgwire::api::query::{ExtendedQueryHandler, SimpleQueryHandler};
@@ -691,18 +693,9 @@ fn batch_to_row_stream(
 
 #[async_trait]
 impl SimpleQueryHandler for DatafusionBackend {
-    async fn do_query<C>(
-        &self,
-        client: &mut C,
-        query: &str,
-    ) -> PgWireResult<Vec<Response>>
+    async fn do_query<C>(&self, client: &mut C, query: &str) -> PgWireResult<Vec<Response>>
     where
-        C: ClientInfo
-            + ClientPortalStore
-            + Sink<PgWireBackendMessage>
-            + Unpin
-            + Send
-            + Sync,
+        C: ClientInfo + ClientPortalStore + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
         C::Error: std::fmt::Debug,
         PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
     {
@@ -852,12 +845,7 @@ impl ExtendedQueryHandler for DatafusionBackend {
         _max_rows: usize,
     ) -> PgWireResult<Response>
     where
-        C: ClientInfo
-            + ClientPortalStore
-            + Sink<PgWireBackendMessage>
-            + Unpin
-            + Send
-            + Sync,
+        C: ClientInfo + ClientPortalStore + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
         C::PortalStore: pgwire::api::store::PortalStore<Statement = Self::Statement>,
         C::Error: std::fmt::Debug,
         PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
@@ -975,12 +963,7 @@ impl ExtendedQueryHandler for DatafusionBackend {
         stmt: &StoredStatement<Self::Statement>,
     ) -> PgWireResult<DescribeStatementResponse>
     where
-        C: ClientInfo
-            + ClientPortalStore
-            + Sink<PgWireBackendMessage>
-            + Unpin
-            + Send
-            + Sync,
+        C: ClientInfo + ClientPortalStore + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
         C::PortalStore: PortalStore<Statement = Self::Statement>,
         C::Error: std::fmt::Debug,
         PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
@@ -1046,12 +1029,7 @@ impl ExtendedQueryHandler for DatafusionBackend {
         portal: &Portal<Self::Statement>,
     ) -> PgWireResult<DescribePortalResponse>
     where
-        C: ClientInfo
-            + ClientPortalStore
-            + Sink<PgWireBackendMessage>
-            + Unpin
-            + Send
-            + Sync,
+        C: ClientInfo + ClientPortalStore + Sink<PgWireBackendMessage> + Unpin + Send + Sync,
         C::PortalStore: PortalStore<Statement = Self::Statement>,
         C::Error: std::fmt::Debug,
         PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,

--- a/src/server.rs
+++ b/src/server.rs
@@ -7,11 +7,11 @@ use std::sync::{Arc, Mutex};
 use arrow::array::{Array, ArrayRef, Float32Array, Float64Array};
 use async_trait::async_trait;
 use bytes::Bytes;
-use futures::stream::BoxStream;
+use futures::sink::Sink;
 use futures::{stream, Stream};
 use pgwire::api::auth::md5pass::{hash_md5_password, Md5PasswordAuthStartupHandler};
-use pgwire::api::auth::{AuthSource, DefaultServerParameterProvider, LoginInfo, Password};
-use pgwire::api::copy::NoopCopyHandler;
+use pgwire::api::auth::{AuthSource, DefaultServerParameterProvider, LoginInfo, Password, StartupHandler};
+use pgwire::api::copy::CopyHandler;
 use pgwire::api::portal::{Format, Portal};
 use pgwire::api::query::{ExtendedQueryHandler, SimpleQueryHandler};
 use pgwire::api::results::{
@@ -19,9 +19,11 @@ use pgwire::api::results::{
     QueryResponse, Response, Tag,
 };
 use pgwire::api::stmt::{NoopQueryParser, StoredStatement};
-use pgwire::api::{ClientInfo, PgWireServerHandlers, Type};
+use pgwire::api::store::PortalStore;
+use pgwire::api::{ClientInfo, ClientPortalStore, NoopHandler, PgWireServerHandlers, Type};
 use pgwire::error::{PgWireError, PgWireResult};
 use pgwire::messages::data::DataRow;
+use pgwire::messages::PgWireBackendMessage;
 use pgwire::tokio::process_socket;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -262,7 +264,7 @@ impl DatafusionBackend {
         Ok(())
     }
 
-    fn show_variable_response<'a>(&self, name: &str, format: FieldFormat) -> Option<Response<'a>> {
+    fn show_variable_response(&self, name: &str, format: FieldFormat) -> Option<Response> {
         let state = self.ctx.state();
         let opts = state.config_options().extensions.get::<ClientOpts>()?;
 
@@ -285,7 +287,6 @@ impl DatafusionBackend {
         encoder.encode_field(&Some(value)).ok()?;
         let row = encoder.finish().ok()?;
         let rows = stream::iter(vec![Ok(row)]);
-        let rows: BoxStream<'a, PgWireResult<DataRow>> = Box::pin(rows);
         Some(Response::Query(QueryResponse::new(fields, rows)))
     }
 
@@ -304,6 +305,7 @@ impl DatafusionBackend {
     }
 }
 
+#[derive(Debug)]
 pub struct DummyAuthSource;
 
 #[async_trait]
@@ -503,7 +505,7 @@ fn decode_parameters(params: &[Option<Bytes>], types: &[Type]) -> Vec<Option<ser
 fn batch_to_row_stream(
     batch: &RecordBatch,
     schema: Arc<Vec<FieldInfo>>,
-) -> impl Stream<Item = PgWireResult<DataRow>> {
+) -> impl Stream<Item = PgWireResult<DataRow>> + Send + 'static {
     let mut rows = Vec::new();
     for row_idx in 0..batch.num_rows() {
         let mut encoder = DataRowEncoder::new(schema.clone());
@@ -689,13 +691,20 @@ fn batch_to_row_stream(
 
 #[async_trait]
 impl SimpleQueryHandler for DatafusionBackend {
-    async fn do_query<'a, C>(
+    async fn do_query<C>(
         &self,
         client: &mut C,
-        query: &'a str,
-    ) -> PgWireResult<Vec<Response<'a>>>
+        query: &str,
+    ) -> PgWireResult<Vec<Response>>
     where
-        C: ClientInfo + Unpin + Send + Sync,
+        C: ClientInfo
+            + ClientPortalStore
+            + Sink<PgWireBackendMessage>
+            + Unpin
+            + Send
+            + Sync,
+        C::Error: std::fmt::Debug,
+        PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
     {
         log::debug!("query handler");
         let trimmed = query.trim();
@@ -836,14 +845,22 @@ impl ExtendedQueryHandler for DatafusionBackend {
         self.query_parser.clone()
     }
 
-    async fn do_query<'a, C>(
+    async fn do_query<C>(
         &self,
         client: &mut C,
-        portal: &'a Portal<Self::Statement>,
+        portal: &Portal<Self::Statement>,
         _max_rows: usize,
-    ) -> PgWireResult<Response<'a>>
+    ) -> PgWireResult<Response>
     where
-        C: ClientInfo + Unpin + Send + Sync,
+        C: ClientInfo
+            + ClientPortalStore
+            + Sink<PgWireBackendMessage>
+            + Unpin
+            + Send
+            + Sync,
+        C::PortalStore: pgwire::api::store::PortalStore<Statement = Self::Statement>,
+        C::Error: std::fmt::Debug,
+        PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
     {
         log::debug!(
             "query start extended {:?} {:?}",
@@ -958,7 +975,15 @@ impl ExtendedQueryHandler for DatafusionBackend {
         stmt: &StoredStatement<Self::Statement>,
     ) -> PgWireResult<DescribeStatementResponse>
     where
-        C: ClientInfo + Unpin + Send + Sync,
+        C: ClientInfo
+            + ClientPortalStore
+            + Sink<PgWireBackendMessage>
+            + Unpin
+            + Send
+            + Sync,
+        C::PortalStore: PortalStore<Statement = Self::Statement>,
+        C::Error: std::fmt::Debug,
+        PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
     {
         log::debug!("do_describe_statement");
 
@@ -1021,7 +1046,15 @@ impl ExtendedQueryHandler for DatafusionBackend {
         portal: &Portal<Self::Statement>,
     ) -> PgWireResult<DescribePortalResponse>
     where
-        C: ClientInfo + Unpin + Send + Sync,
+        C: ClientInfo
+            + ClientPortalStore
+            + Sink<PgWireBackendMessage>
+            + Unpin
+            + Send
+            + Sync,
+        C::PortalStore: PortalStore<Statement = Self::Statement>,
+        C::Error: std::fmt::Debug,
+        PgWireError: From<<C as Sink<PgWireBackendMessage>>::Error>,
     {
         log::debug!("do_describe_portal");
         let sql_trim = portal.statement.statement.trim();
@@ -1087,22 +1120,15 @@ pub struct DatafusionBackendFactory {
 }
 
 impl PgWireServerHandlers for DatafusionBackendFactory {
-    type StartupHandler =
-        Md5PasswordAuthStartupHandler<DummyAuthSource, DefaultServerParameterProvider>;
-    type SimpleQueryHandler = DatafusionBackend;
-    type ExtendedQueryHandler = DatafusionBackend;
-    type CopyHandler = NoopCopyHandler;
-    type ErrorHandler = pgwire::api::NoopErrorHandler;
-
-    fn simple_query_handler(&self) -> Arc<Self::SimpleQueryHandler> {
+    fn simple_query_handler(&self) -> Arc<impl SimpleQueryHandler> {
         self.handler.clone()
     }
 
-    fn extended_query_handler(&self) -> Arc<Self::ExtendedQueryHandler> {
+    fn extended_query_handler(&self) -> Arc<impl ExtendedQueryHandler> {
         self.handler.clone()
     }
 
-    fn startup_handler(&self) -> Arc<Self::StartupHandler> {
+    fn startup_handler(&self) -> Arc<impl StartupHandler> {
         let mut params = DefaultServerParameterProvider::default();
         params.server_version = SERVER_VERSION.to_string();
         Arc::new(Md5PasswordAuthStartupHandler::new(
@@ -1111,12 +1137,12 @@ impl PgWireServerHandlers for DatafusionBackendFactory {
         ))
     }
 
-    fn copy_handler(&self) -> Arc<Self::CopyHandler> {
-        Arc::new(NoopCopyHandler)
+    fn copy_handler(&self) -> Arc<impl CopyHandler> {
+        Arc::new(NoopHandler)
     }
 
-    fn error_handler(&self) -> Arc<Self::ErrorHandler> {
-        Arc::new(pgwire::api::NoopErrorHandler)
+    fn error_handler(&self) -> Arc<impl pgwire::api::ErrorHandler> {
+        Arc::new(NoopHandler)
     }
 }
 


### PR DESCRIPTION
## Summary
- bump the pgwire dependency to 0.33.0 and refresh Cargo.lock to include the crate's updated transitive requirements
- adjust the server implementation to the revised pgwire handler traits, including deriving `Debug` for `DummyAuthSource`
- update simple query utilities to produce `'static` response streams compatible with the new API

## Testing
- cargo build
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e3a33de724832fbf609c161c50e1bc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Chores
  * Upgraded PostgreSQL wire protocol dependency to 0.33.0 for improved compatibility.

* Refactor
  * Streamlined server handler integrations and public interfaces to improve compatibility and runtime stability.
  * Simplified query/stream handling and tightened bounds for more reliable streaming and response behavior.
  * Improved startup, copy, and error handling flows with no expected changes to typical usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->