### PR TITLE
Upgrade pgwire dependency to 0.34

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2787,9 +2787,9 @@ dependencies = [
 
 [[package]]
 name = "pgwire"
-version = "0.33.0"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58d371668e6151da16be31308989058156c01257277ea8af0f97524e87cfa31"
+checksum = "4f56a81b4fcc69016028f657a68f9b8e8a2a4b7d07684ca3298f2d3e7ff199ce"
 dependencies = [
  "async-trait",
  "aws-lc-rs",
@@ -2805,6 +2805,8 @@ dependencies = [
  "rand 0.9.2",
  "rust_decimal",
  "rustls-pki-types",
+ "serde",
+ "serde_json",
  "stringprep",
  "thiserror",
  "tokio",
@@ -2893,6 +2895,8 @@ dependencies = [
  "chrono",
  "fallible-iterator",
  "postgres-protocol",
+ "serde_core",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ serde_yaml = "0.9"
 regex = "1"
 async-trait = "0.1"
 uuid = { version = "1.16.0", features = ["v4"] }
-pgwire = "0.33.0"
+pgwire = "0.34"
 futures = "0.3.31"
 anyhow = "1.0.98"
 bytes = "1.10.1"


### PR DESCRIPTION
## Summary
- update the pgwire dependency to version 0.34
- refresh Cargo.lock to pull in the new transitive requirements

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68fa36562d40832f9b298430cd476aaa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pgwire dependency to the latest version for improved stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->