### PR TITLE
missing functions

### DIFF
--- a/CATALOG-REFERENCE.md
+++ b/CATALOG-REFERENCE.md
@@ -46,9 +46,11 @@ Both paths share the same pure row-builders (`build_pg_class_row`,
 ### How that reaches the **views**
 Views are not registered directly - they derive from base tables. Three behaviours:
 
-- **live** - re-derived from `pg_class` on every query, so it **reflects
-  runtime-registered user objects immediately**. Only `pg_tables` and `pg_views`
-  (`VIEW_ONLY_TABLES` in `src/session.rs`).
+- **live** - re-derived from its base tables on every query, so it **reflects
+  runtime-registered user objects immediately**. `VIEW_ONLY_TABLES` in
+  `src/session.rs`: `pg_tables`, `pg_views`, and the four constraint views
+  (`table_constraints`, `key_column_usage`, `constraint_column_usage`,
+  `referential_constraints`, derived from the registrable `pg_constraint`).
 - **merge** - the lazy/eager registration target itself: `information_schema.tables`,
   `information_schema.columns`, `information_schema.schemata` are wrapped by the
   lazy provider (and written by `register_user_tables`), so they **reflect user
@@ -221,7 +223,7 @@ see above). `Reads from` = the main catalog tables the view's SQL joins.
 | View | Purpose | Reads from | Reflects | Diverging | Reason |
 |---|---|---|---|---|---|
 | `pg_views` | All views + their defining SQL. | pg_class, pg_namespace | **live** | `definition` | `pg_get_viewdef` not implemented (node-tree deparse). |
-| `pg_indexes` | All indexes + their `CREATE INDEX` text. | pg_index, pg_class, pg_namespace, pg_tablespace | static | `indexdef` | `pg_get_indexdef` is a stub; `pg_index` now registrable, templating is the next task. |
+| `pg_indexes` | All indexes + their `CREATE INDEX` text. | pg_index, pg_class, pg_namespace, pg_tablespace | static | working | `pg_get_indexdef` templates the `CREATE INDEX` text for plain indexes from live catalog rows; functional/partial expression text is Phase 2. |
 | `pg_rules` | Rewrite rules + their defining SQL. | pg_rewrite, pg_class, pg_namespace | static | `definition` | `pg_get_ruledef` not implemented. |
 
 ### Broken - fixable engine/UDF gaps (9)
@@ -316,7 +318,7 @@ the rest are `static` snapshots.
 | `column_privileges` | Column-level privileges. | pg_class, pg_attribute, pg_authid | static | partial - empty: GRANTs not modeled. |
 | `column_udt_usage` | Columns and their underlying type. | pg_attribute, pg_namespace | static | working |
 | `columns` | All table/view columns. | pg_attribute, pg_namespace, pg_attrdef | **merge** | partial - is_updatable NULL on 4 columns (pg_relation_is_updatable stub). |
-| `constraint_column_usage` | Columns referenced by constraints. | pg_constraint, pg_attribute | static | working |
+| `constraint_column_usage` | Columns referenced by constraints. | pg_constraint, pg_attribute | live | working |
 | `constraint_table_usage` | Tables referenced by constraints. | pg_constraint, pg_class | static | working |
 | `data_type_privileges` | Type-usage privilege scopes. | attributes, columns, domains, parameters | static | working |
 | `domain_constraints` | Constraints attached to domains. | pg_constraint, pg_type | static | working |
@@ -331,9 +333,9 @@ the rest are `static` snapshots.
 | `foreign_table_options` | Foreign-table option pairs. | pg_foreign_table | static | working |
 | `foreign_tables` | Foreign tables. | pg_foreign_table | static | working |
 | `information_schema_catalog_name` | Name of the current database. | (constant) | static | working |
-| `key_column_usage` | Columns in PK/UNIQUE/FK constraints. | pg_constraint, pg_attribute | static | working |
+| `key_column_usage` | Columns in PK/UNIQUE/FK constraints. | pg_constraint, pg_attribute | live | working |
 | `parameters` | Function/procedure parameters. | pg_proc, pg_type, pg_namespace | static | partial - `parameter_default` NULL (`pg_get_function_arg_default` stub). |
-| `referential_constraints` | Foreign-key constraint metadata. | pg_constraint, pg_class, pg_depend | static | working |
+| `referential_constraints` | Foreign-key constraint metadata. | pg_constraint, pg_class, pg_depend | live | working |
 | `role_column_grants` | Column grants to enabled roles. | column_privileges, enabled_roles | static | working |
 | `role_routine_grants` | Routine (EXECUTE) grants to enabled roles. | routine_privileges, enabled_roles | static | working |
 | `role_table_grants` | Table grants to enabled roles. | table_privileges, enabled_roles | static | working |
@@ -347,7 +349,7 @@ the rest are `static` snapshots.
 | `routines` | Functions and procedures. | pg_proc, pg_namespace, pg_language | static | working |
 | `schemata` | Schemas in the database. | pg_namespace | **merge** | working |
 | `sequences` | Sequences + type/limits. | pg_sequence, pg_class, pg_namespace | static | working |
-| `table_constraints` | All table constraints. | pg_constraint, pg_class, pg_namespace | static | working |
+| `table_constraints` | All table constraints. | pg_constraint, pg_class, pg_namespace | live | working |
 | `table_privileges` | Table-level privileges. | pg_class, pg_authid | static | partial - empty: GRANTs not modeled. |
 | `tables` | All tables and views. | pg_class, pg_namespace | **merge** | partial - is_insertable_into not reproduced for a couple of views. |
 | `transforms` | Type/language transform functions. | pg_type, pg_transform, pg_language, pg_proc | static | working |

--- a/TODO.md
+++ b/TODO.md
@@ -18,13 +18,16 @@ Do NOT bake per-database/dynamic answers (indexes, views, constraints, defaults)
 of it by oid lookup - a user's runtime object is not in the dump.
 
 Runtime registration today populates `pg_class`, `pg_attribute`, `pg_namespace`,
-`pg_type`, `pg_database`, and `pg_index`, via two interchangeable paths that share
-the same row-builders:
+`pg_type`, `pg_database`, `pg_index`, `pg_constraint`, and `pg_attrdef` (the
+structural handle; default text is Phase 3), via two interchangeable paths that
+share the same row-builders:
 - eager / pre-register: `register_user_database`, `register_schema`,
-  `register_user_tables`, `register_user_index`.
-- lazy / callback: a `LazyCatalogSource` implementation + `register_lazy_catalog`.
+  `register_user_tables` (emits `pg_attrdef` for defaulted columns),
+  `register_user_index`, `register_user_constraint`.
+- lazy / callback: a `LazyCatalogSource` implementation + `register_lazy_catalog`
+  (a column's `ColumnSpec::with_default` drives its `pg_attrdef` row).
 
-Still seed-only for user objects: `pg_constraint`, `pg_rewrite`, `pg_attrdef`.
+Still seed-only for user objects: `pg_rewrite`.
 
 ## The strategic pivot: the integration supplies definitions, we never deparse
 
@@ -43,7 +46,8 @@ let the integration **supply** the human-facing strings and flags. When a defini
 is not supplied, the column stays NULL (today's behavior) - it is purely opt-in.
 
 This reframes the single biggest item on the old backlog ("reimplement the deparser")
-into "add optional definition fields to the registration API" - which is Phase 2.
+into "add optional definition fields to the registration API" - which is Phase 3
+(gated by the Phase 2 pool redesign, since those UDFs do nested catalog lookups).
 
 What stays structural (no deparse, fully ours to compute): a *plain* index's
 `CREATE INDEX` text is determined by data we already hold
@@ -55,36 +59,46 @@ functional/partial index *expressions* need supplied text.
 ## Phase 1 - Finish structured user-object registration (no deparse)
 
 Goal: a registered user table is fully introspectable from structured data alone.
+The structured registration surface is complete: `pg_class`, `pg_type`,
+`pg_attribute`, `pg_index`, `pg_constraint` (PK/UNIQUE/FK), and `pg_attrdef` (the
+`atthasdef` flag + the `pg_attrdef` handle) are all populated by both the eager and
+lazy paths through the shared row-builders.
 
-- `pg_get_indexdef` for plain indexes via templating, from live catalog rows at call
-  time (read whatever `pg_index` holds, seeded + user). Build
-  `CREATE [UNIQUE] INDEX name ON schema.tbl USING am (col, ...)` from
-  `pg_class`/`pg_index`/`pg_am`/`pg_attribute`. Leave functional/partial expression
-  text to Phase 2. When done: drop `pg_catalog.pg_indexes` from
-  `KNOWN_CONTENT_MISMATCHES` and confirm the snapshot test goes green.
-- `pg_constraint` registration (structured): PK / FK / UNIQUE described by their key
-  columns and referenced relation. Feeds `table_constraints`, `key_column_usage`,
-  `constraint_column_usage`, `referential_constraints` for user tables. Mirror the
-  `IndexDef` shape (one `ConstraintDef` -> the `pg_constraint` row(s); FK target
-  resolved by oid).
-- `pg_attrdef` registration (structured handle + supplied text): the column-default
-  text is integration-supplied (Phase 2 territory), but the `pg_attrdef` row and
-  `pg_attribute.atthasdef` flag are structural and belong here.
-- Column-fidelity audit: the lazy/eager row-builders set only a subset of each
-  catalog table's columns; the rest are NULL though real PostgreSQL has many NOT
-  NULL. Fill the columns clients actually read. Known-NULL today: `pg_class` (relam,
-  relfilenode, reltablespace, relpages, relnatts, relchecks, relhassubclass, ...),
-  `pg_type` (typbyval, typelem, typarray, typinput/output/..., typalign, ...),
-  `pg_attribute` (attlen, attbyval, attalign, attstorage, attidentity, attinhcount,
-  attcollation, ...). `pg_database`/`pg_namespace` are already complete.
-- Retrofit `register_user_tables` onto the shared `build_*_row` helpers +
-  `append_catalog_row` (the lazy path and `register_user_index` already do this;
-  `register_user_tables` still emits raw SQL `INSERT`s - the last drift source).
+- Column-fidelity long tail: the row-builders now fill the columns clients commonly
+  read - `pg_class` (relam, relnatts, relfilenode, relpages, relchecks,
+  relhassubclass, reltablespace, relfrozenxid, relminmxid, ...), `pg_type`
+  (typbyval, typalign, typstorage, typinput/output/receive/send, typelem, typarray,
+  ...), `pg_attribute` (attlen, attbyval, attalign, attstorage, attcollation,
+  attidentity, attgenerated, attinhcount, ...). Remaining NULL columns are
+  filled on demand as specific clients turn out to read them; `pg_database`/
+  `pg_namespace` were already complete.
 
-## Phase 2 - Integration-supplied definition text (the deparse pivot)
+## Phase 2 - Engine robustness and scale
+
+Reordered ahead of the deparse pivot (now Phase 3): the pool redesign gates it,
+because each definition-text UDF does a nested catalog sub-query the current bounded
+pool cannot survive (see Hazard below).
+
+- Catalog-UDF sync-over-async pool redesign (see Hazard below). Replace the bounded
+  `CATALOG_QUERY_RT` + blocking `rx.recv()` with a scheme that cannot deadlock under
+  UDF composition (a pool that grows/borrows a worker when one blocks, or restructure
+  the UDFs to avoid a nested blocking catalog query).
+- Lazy-source filter pushdown: implement `supports_filters_pushdown` on
+  `LazyCatalogTableProvider` and push equality filters (`relname=`, `nspname=`,
+  `datname=`) into the source, so a large catalog is not fully re-enumerated per scan.
+- Promote the static relation-listing views (`pg_indexes`, `pg_matviews`,
+  `pg_sequences`) to live views over the registration where it makes sense -
+  `VIEW_ONLY_TABLES` now covers `pg_tables`/`pg_views` plus the four constraint
+  views (`table_constraints`, `key_column_usage`, `constraint_column_usage`,
+  `referential_constraints`); the remaining relation-listing views are still
+  static snapshots that do not reflect registered user objects.
+
+## Phase 3 - Integration-supplied definition text (the deparse pivot)
 
 Goal: views/constraints/defaults become fully introspectable for integrations that
-provide the text, without us ever shipping a node-tree deparser.
+provide the text, without us ever shipping a node-tree deparser. Depends on the
+Phase 2 pool redesign - each UDF below reads supplied text via a nested catalog
+lookup.
 
 - Extend the registration contract with optional definition fields:
   - view definition SQL + updatability flags on a `ViewDef`/`RelationDef`
@@ -104,7 +118,7 @@ provide the text, without us ever shipping a node-tree deparser.
   live catalog at call time (the runtime-catalog-lookup pattern used by
   `pg_get_userbyid`), returning NULL / the safe default when nothing was supplied.
 
-## Phase 3 - Session/GUC and SQL-surface compatibility
+## Phase 4 - Session/GUC and SQL-surface compatibility
 
 Goal: behave like PostgreSQL for the session-control surface tools rely on, and clear
 the self-contained "broken view" gaps.
@@ -128,22 +142,8 @@ Self-contained broken views (see `CATALOG-REFERENCE.md` "fixable" list):
   (sqlparser `ARRAY` parse error), `pg_stats_ext` (`s.stxkeys` scoping).
 - `is_updatable` (4 cols) / `is_insertable_into` (2 views): the
   `pg_relation_is_updatable` stub returns 0. Real value is structural (view
-  auto-updatability), but per the Phase 2 pivot it should be integration-supplied;
+  auto-updatability), but per the Phase 3 pivot it should be integration-supplied;
   niche, leave stubbed with the precise snapshot baseline until then.
-
-## Phase 4 - Engine robustness and scale
-
-- Catalog-UDF sync-over-async pool redesign (see Hazard below). Replace the bounded
-  `CATALOG_QUERY_RT` + blocking `rx.recv()` with a scheme that cannot deadlock under
-  UDF composition (a pool that grows/borrows a worker when one blocks, or restructure
-  the UDFs to avoid a nested blocking catalog query).
-- Lazy-source filter pushdown: implement `supports_filters_pushdown` on
-  `LazyCatalogTableProvider` and push equality filters (`relname=`, `nspname=`,
-  `datname=`) into the source, so a large catalog is not fully re-enumerated per scan.
-- Promote the static relation-listing views (`pg_indexes`, `pg_matviews`,
-  `pg_sequences`) to live views over the registration where it makes sense - today
-  only `pg_tables`/`pg_views` are live (`VIEW_ONLY_TABLES`); the rest are static
-  snapshots that do not reflect registered user objects.
 
 ## Phase 5 - Runtime/monitoring views (optional, integration-driven)
 
@@ -193,11 +193,13 @@ Why we are safe today: the sub-queries are plain UDF-free scans
 relname = '...'`), so nesting depth is always exactly 1. The whole thing rests on this
 one assumption: catalog sub-queries stay UDF-free. The day a built-in view/UDF
 resolves one catalog UDF via another, the bounded pool is the failure point; bumping
-`worker_threads` only moves the cliff. The fix is Phase 4.
+`worker_threads` only moves the cliff. The fix is Phase 2.
 
-Note: the Phase 2 pivot (UDFs reading supplied definition text from the catalog at
-call time) ADDS catalog sub-queries inside UDFs - so land the Phase 4 pool redesign
-before, or alongside, any Phase 2 UDF that does a nested catalog lookup.
+Note: the Phase 3 pivot (UDFs reading supplied definition text from the catalog at
+call time) ADDS catalog sub-queries inside UDFs - so land the Phase 2 pool redesign
+before, or alongside, any Phase 3 UDF that does a nested catalog lookup. This
+ordering (engine robustness before the deparse pivot) is exactly why Phase 2 and
+Phase 3 are sequenced as they are.
 
 ## Operational gotchas
 
@@ -221,7 +223,7 @@ before, or alongside, any Phase 2 UDF that does a nested catalog lookup.
 
 ## Validate ("all green" - CLAUDE.md: can't call it done without all tests)
 
-- Rust: `cargo test` - expect 136 lib + integration bins, 0 failures.
+- Rust: `cargo test` - expect 139 lib + integration bins, 0 failures.
 - Python: `.venv/bin/python -m pytest tests/ -q` - expect 54 passed, 1 skipped.
   Do NOT set `RUST_LOG=off` for the full suite: the spawned server inherits it and
   `test_error_logging` greps the server log for `exec_error`. `RUST_LOG=off` is only

--- a/src/lazy_catalog.rs
+++ b/src/lazy_catalog.rs
@@ -235,6 +235,224 @@ impl IndexDef {
     }
 }
 
+/// The kind of table constraint a [`ConstraintDef`] describes. Check constraints
+/// are excluded: their defining SQL is a node tree we do not deparse, so their
+/// text is integration-supplied (Phase 2) rather than structural.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ConstraintKind {
+    /// A primary key (`pg_constraint.contype = 'p'`).
+    PrimaryKey,
+    /// A unique constraint (`pg_constraint.contype = 'u'`).
+    Unique,
+    /// A foreign key (`pg_constraint.contype = 'f'`).
+    ForeignKey,
+}
+
+impl ConstraintKind {
+    /// The single-character `pg_constraint.contype` code for this kind.
+    pub fn contype(&self) -> &'static str {
+        match self {
+            ConstraintKind::PrimaryKey => "p",
+            ConstraintKind::Unique => "u",
+            ConstraintKind::ForeignKey => "f",
+        }
+    }
+}
+
+/// The action a foreign key takes on UPDATE or DELETE of a referenced row
+/// (`pg_constraint.confupdtype` / `confdeltype`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ForeignKeyAction {
+    /// `NO ACTION` (`a`) - the default; reject the change if references remain.
+    NoAction,
+    /// `RESTRICT` (`r`).
+    Restrict,
+    /// `CASCADE` (`c`).
+    Cascade,
+    /// `SET NULL` (`n`).
+    SetNull,
+    /// `SET DEFAULT` (`d`).
+    SetDefault,
+}
+
+impl ForeignKeyAction {
+    /// The single-character action code stored in `pg_constraint`.
+    pub fn code(&self) -> &'static str {
+        match self {
+            ForeignKeyAction::NoAction => "a",
+            ForeignKeyAction::Restrict => "r",
+            ForeignKeyAction::Cascade => "c",
+            ForeignKeyAction::SetNull => "n",
+            ForeignKeyAction::SetDefault => "d",
+        }
+    }
+}
+
+/// How a foreign key matches a multi-column reference
+/// (`pg_constraint.confmatchtype`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ForeignKeyMatch {
+    /// `MATCH FULL` (`f`).
+    Full,
+    /// `MATCH PARTIAL` (`p`).
+    Partial,
+    /// `MATCH SIMPLE` (`s`) - the default.
+    Simple,
+}
+
+impl ForeignKeyMatch {
+    /// The single-character match-type code stored in `pg_constraint`.
+    pub fn code(&self) -> &'static str {
+        match self {
+            ForeignKeyMatch::Full => "f",
+            ForeignKeyMatch::Partial => "p",
+            ForeignKeyMatch::Simple => "s",
+        }
+    }
+}
+
+/// One constraint fed into `pg_catalog.pg_constraint`.
+///
+/// Describes a primary-key, unique, or foreign-key constraint structurally - by
+/// its key columns, and (for a foreign key) the referenced relation and columns.
+/// A single [`ConstraintDef`] becomes one `pg_constraint` row, which the
+/// `information_schema` constraint views (`table_constraints`,
+/// `key_column_usage`, `constraint_column_usage`, `referential_constraints`)
+/// derive from. FK targets are given as OIDs the source already knows.
+#[derive(Clone, Debug)]
+pub struct ConstraintDef {
+    /// The constraint's `pg_constraint.oid`.
+    pub oid: i32,
+    /// The constraint name (`conname`).
+    pub name: String,
+    /// Primary key, unique, or foreign key (`contype`).
+    pub kind: ConstraintKind,
+    /// The schema OID the constraint belongs to (`connamespace`), normally the
+    /// constrained table's schema.
+    pub namespace_oid: i32,
+    /// The constrained table's `pg_class.oid` (`conrelid`).
+    pub table_oid: i32,
+    /// The constrained columns as 1-based attnums in key order (`conkey`).
+    pub key_attnums: Vec<i32>,
+    /// The OID of the index backing this constraint (`conindid`), or 0 if none.
+    /// PK/UNIQUE constraints are normally backed by a unique index.
+    pub index_oid: i32,
+    /// For a foreign key, the referenced table's `pg_class.oid` (`confrelid`); 0
+    /// for primary-key and unique constraints.
+    pub referenced_table_oid: i32,
+    /// For a foreign key, the referenced columns as 1-based attnums (`confkey`),
+    /// positionally matched to `key_attnums`; empty for non-foreign-key kinds.
+    pub referenced_key_attnums: Vec<i32>,
+    /// A foreign key's `ON UPDATE` action (`confupdtype`).
+    pub on_update: ForeignKeyAction,
+    /// A foreign key's `ON DELETE` action (`confdeltype`).
+    pub on_delete: ForeignKeyAction,
+    /// A foreign key's match type (`confmatchtype`).
+    pub match_type: ForeignKeyMatch,
+}
+
+impl ConstraintDef {
+    /// Construct a primary-key constraint over `key_attnums` of `table_oid`,
+    /// backed by `index_oid` (the unique index implementing it; pass 0 if none).
+    pub fn primary_key(
+        oid: i32,
+        name: impl Into<String>,
+        namespace_oid: i32,
+        table_oid: i32,
+        key_attnums: Vec<i32>,
+        index_oid: i32,
+    ) -> Self {
+        Self::key_constraint(
+            ConstraintKind::PrimaryKey,
+            oid,
+            name,
+            namespace_oid,
+            table_oid,
+            key_attnums,
+            index_oid,
+        )
+    }
+
+    /// Construct a unique constraint over `key_attnums` of `table_oid`, backed by
+    /// `index_oid` (the unique index implementing it; pass 0 if none).
+    pub fn unique(
+        oid: i32,
+        name: impl Into<String>,
+        namespace_oid: i32,
+        table_oid: i32,
+        key_attnums: Vec<i32>,
+        index_oid: i32,
+    ) -> Self {
+        Self::key_constraint(
+            ConstraintKind::Unique,
+            oid,
+            name,
+            namespace_oid,
+            table_oid,
+            key_attnums,
+            index_oid,
+        )
+    }
+
+    /// Shared constructor for the key-only constraint kinds (primary key and
+    /// unique), which reference no other relation.
+    fn key_constraint(
+        kind: ConstraintKind,
+        oid: i32,
+        name: impl Into<String>,
+        namespace_oid: i32,
+        table_oid: i32,
+        key_attnums: Vec<i32>,
+        index_oid: i32,
+    ) -> Self {
+        Self {
+            oid,
+            name: name.into(),
+            kind,
+            namespace_oid,
+            table_oid,
+            key_attnums,
+            index_oid,
+            referenced_table_oid: 0,
+            referenced_key_attnums: Vec::new(),
+            on_update: ForeignKeyAction::NoAction,
+            on_delete: ForeignKeyAction::NoAction,
+            match_type: ForeignKeyMatch::Simple,
+        }
+    }
+
+    /// Construct a foreign-key constraint: `key_attnums` of `table_oid` reference
+    /// `referenced_key_attnums` of `referenced_table_oid`, positionally matched.
+    /// The ON UPDATE / ON DELETE actions default to NO ACTION and the match type
+    /// to SIMPLE; set those fields afterward to change them.
+    #[allow(clippy::too_many_arguments)]
+    pub fn foreign_key(
+        oid: i32,
+        name: impl Into<String>,
+        namespace_oid: i32,
+        table_oid: i32,
+        key_attnums: Vec<i32>,
+        referenced_table_oid: i32,
+        referenced_key_attnums: Vec<i32>,
+        index_oid: i32,
+    ) -> Self {
+        Self {
+            oid,
+            name: name.into(),
+            kind: ConstraintKind::ForeignKey,
+            namespace_oid,
+            table_oid,
+            key_attnums,
+            index_oid,
+            referenced_table_oid,
+            referenced_key_attnums,
+            on_update: ForeignKeyAction::NoAction,
+            on_delete: ForeignKeyAction::NoAction,
+            match_type: ForeignKeyMatch::Simple,
+        }
+    }
+}
+
 /// One column fed into `pg_attribute` (plus `information_schema.columns`).
 ///
 /// `attrelid` comes from the owning [`RelationDef::oid`]; `attnum` from the
@@ -249,17 +467,30 @@ pub struct ColumnSpec {
     pub type_oid: i32,
     /// Whether the column admits NULLs (`pg_attribute.attnotnull` is its negation).
     pub nullable: bool,
+    /// Whether the column has a default expression (`pg_attribute.atthasdef`, and
+    /// a backing `pg_attrdef` row). The default *text* is integration-supplied
+    /// (Phase 2); this flag and the `pg_attrdef` handle are the structural part.
+    pub has_default: bool,
 }
 
 impl ColumnSpec {
     /// Construct a column specification from a name, `pg_type` OID, and
-    /// nullability.
+    /// nullability, with no column default.
     pub fn new(name: impl Into<String>, type_oid: i32, nullable: bool) -> Self {
         Self {
             name: name.into(),
             type_oid,
             nullable,
+            has_default: false,
         }
+    }
+
+    /// Mark this column as having a default expression, so it gets a `pg_attrdef`
+    /// row and `pg_attribute.atthasdef = true`. The default text itself is
+    /// supplied later (Phase 2).
+    pub fn with_default(mut self) -> Self {
+        self.has_default = true;
+        self
     }
 }
 
@@ -315,6 +546,22 @@ pub trait LazyCatalogSource: Send + Sync {
         Ok(())
     }
 
+    /// Constraints in `database`.`schema` -> `pg_catalog.pg_constraint`.
+    ///
+    /// Has a default that contributes nothing, so existing implementors expose no
+    /// constraints and keep compiling. Override it to report a relation's
+    /// primary-key/unique/foreign-key constraints so the `information_schema`
+    /// constraint views describe them. Each returned [`ConstraintDef`]'s `oid`
+    /// must be distinct from every relation and index OID.
+    fn constraints(
+        &self,
+        _database: &str,
+        _schema: &str,
+        _callback: &mut dyn FnMut(Vec<ConstraintDef>),
+    ) -> DFResult<()> {
+        Ok(())
+    }
+
     /// `pg_config` build/install settings -> `pg_catalog.pg_config`.
     ///
     /// Has a default that contributes nothing, so existing implementors keep the
@@ -352,6 +599,10 @@ pub enum CatalogTable {
     PgAttribute,
     /// `pg_catalog.pg_index`.
     PgIndex,
+    /// `pg_catalog.pg_constraint`.
+    PgConstraint,
+    /// `pg_catalog.pg_attrdef`.
+    PgAttrdef,
     /// `pg_catalog.pg_config`.
     PgConfig,
     /// `pg_catalog.pg_settings`.
@@ -375,6 +626,8 @@ impl CatalogTable {
             CatalogTable::PgType => ("pg_catalog", "pg_type"),
             CatalogTable::PgAttribute => ("pg_catalog", "pg_attribute"),
             CatalogTable::PgIndex => ("pg_catalog", "pg_index"),
+            CatalogTable::PgConstraint => ("pg_catalog", "pg_constraint"),
+            CatalogTable::PgAttrdef => ("pg_catalog", "pg_attrdef"),
             CatalogTable::PgConfig => ("pg_catalog", "pg_config"),
             CatalogTable::PgSettings => ("pg_catalog", "pg_settings"),
             CatalogTable::InformationSchemaTables => ("information_schema", "tables"),
@@ -401,6 +654,8 @@ impl CatalogTable {
             CatalogTable::PgType => &["typnamespace", "typname"],
             CatalogTable::PgAttribute => &["attrelid", "attname"],
             CatalogTable::PgIndex => &["indexrelid"],
+            CatalogTable::PgConstraint => &["oid"],
+            CatalogTable::PgAttrdef => &["adrelid", "adnum"],
             CatalogTable::PgConfig => &["name"],
             CatalogTable::PgSettings => &["name"],
             CatalogTable::InformationSchemaTables => {
@@ -450,6 +705,17 @@ fn fetch_indexes(
 ) -> DFResult<Vec<IndexDef>> {
     let mut out = Vec::new();
     source.indexes(database, schema, &mut |rows| out.extend(rows))?;
+    Ok(out)
+}
+
+/// Pull the constraints of `database`.`schema` from `source`.
+fn fetch_constraints(
+    source: &dyn LazyCatalogSource,
+    database: &str,
+    schema: &str,
+) -> DFResult<Vec<ConstraintDef>> {
+    let mut out = Vec::new();
+    source.constraints(database, schema, &mut |rows| out.extend(rows))?;
     Ok(out)
 }
 
@@ -596,15 +862,23 @@ pub fn build_pg_namespace_row(def: &SchemaDef) -> Row {
     row
 }
 
-/// Build one `pg_catalog.pg_class` row from a [`RelationDef`] and the OID of its
-/// owning schema.
-pub fn build_pg_class_row(def: &RelationDef, namespace_oid: i32) -> Row {
+/// The `pg_am.oid` of the heap table access method (a fixed PostgreSQL system
+/// OID). An ordinary registered table is heap-stored, so its `pg_class.relam`
+/// points here. (A view/materialized view has no access method; PostgreSQL still
+/// records heap for a materialized view and 0 for a plain view, but heap is a
+/// safe non-NULL default for client introspection either way.)
+pub const HEAP_ACCESS_METHOD_OID: i32 = 2;
+
+/// Build one `pg_catalog.pg_class` row from a [`RelationDef`], the OID of its
+/// owning schema, and its column count (`natts`, written to `relnatts`).
+pub fn build_pg_class_row(def: &RelationDef, namespace_oid: i32, natts: i32) -> Row {
     let mut row = Row::new();
     row.insert("oid".to_string(), json!(def.oid));
     row.insert("relname".to_string(), json!(def.name));
     row.insert("relnamespace".to_string(), json!(namespace_oid));
     row.insert("reltype".to_string(), json!(def.reltype_oid));
     row.insert("relkind".to_string(), json!(def.kind.relkind()));
+    row.insert("relam".to_string(), json!(HEAP_ACCESS_METHOD_OID));
     row.insert("reltuples".to_string(), json!(0.0));
     row.insert("relispartition".to_string(), json!(false));
     // Flags read by pg_tables / pg_views and common client introspection. The
@@ -622,8 +896,28 @@ pub fn build_pg_class_row(def: &RelationDef, namespace_oid: i32) -> Row {
     row.insert("relispopulated".to_string(), json!(true));
     row.insert("relpersistence".to_string(), json!("p"));
     row.insert("relreplident".to_string(), json!("d"));
+    // Structural columns clients read off pg_class for a real relation. The
+    // relation has no separate on-disk file in this layer, so relfilenode mirrors
+    // the OID (PostgreSQL's own default at creation) and the size/freeze counters
+    // are zero.
+    row.insert("relnatts".to_string(), json!(natts));
+    row.insert("relchecks".to_string(), json!(0));
+    row.insert("relhassubclass".to_string(), json!(false));
+    row.insert("relfilenode".to_string(), json!(def.oid));
+    row.insert("reltablespace".to_string(), json!(0));
+    row.insert("relpages".to_string(), json!(0));
+    row.insert("relallvisible".to_string(), json!(0));
+    row.insert("reltoastrelid".to_string(), json!(0));
+    row.insert("relfrozenxid".to_string(), json!(0));
+    row.insert("relminmxid".to_string(), json!(0));
     row
 }
+
+/// The `pg_am.oid` of the B-tree access method (a fixed PostgreSQL system OID).
+/// A registered [`IndexDef`] describes a plain column index, which is always
+/// B-tree, so its `pg_class.relam` points here - letting `pg_get_indexdef`
+/// render `USING btree`.
+pub const BTREE_ACCESS_METHOD_OID: i32 = 403;
 
 /// Build the `pg_catalog.pg_class` row for an index relation (`relkind = 'i'`).
 ///
@@ -638,6 +932,7 @@ pub fn build_index_pg_class_row(def: &IndexDef, namespace_oid: i32) -> Row {
     row.insert("relnamespace".to_string(), json!(namespace_oid));
     row.insert("reltype".to_string(), json!(0));
     row.insert("relkind".to_string(), json!("i"));
+    row.insert("relam".to_string(), json!(BTREE_ACCESS_METHOD_OID));
     row.insert("reltuples".to_string(), json!(0.0));
     row.insert("relispartition".to_string(), json!(false));
     row.insert("relhasindex".to_string(), json!(false));
@@ -679,7 +974,54 @@ pub fn build_pg_index_row(def: &IndexDef) -> Row {
     row
 }
 
+/// Build one `pg_catalog.pg_constraint` row from a [`ConstraintDef`].
+///
+/// The foreign-key fields (`confrelid`/`confkey`/`confupdtype`/`confdeltype`/
+/// `confmatchtype`) carry real values only for a foreign key; for primary-key and
+/// unique constraints they take PostgreSQL's non-FK sentinels (`confrelid` 0,
+/// `confkey` NULL, and the three type codes a single space). The check-expression
+/// column (`conbin`) is left NULL - these kinds have no expression, and check
+/// text is integration-supplied (Phase 2) anyway.
+pub fn build_pg_constraint_row(def: &ConstraintDef) -> Row {
+    let is_foreign_key = def.kind == ConstraintKind::ForeignKey;
+    let mut row = Row::new();
+    row.insert("oid".to_string(), json!(def.oid));
+    row.insert("conname".to_string(), json!(def.name));
+    row.insert("connamespace".to_string(), json!(def.namespace_oid));
+    row.insert("contype".to_string(), json!(def.kind.contype()));
+    row.insert("condeferrable".to_string(), json!(false));
+    row.insert("condeferred".to_string(), json!(false));
+    row.insert("convalidated".to_string(), json!(true));
+    row.insert("conrelid".to_string(), json!(def.table_oid));
+    row.insert("contypid".to_string(), json!(0));
+    row.insert("conindid".to_string(), json!(def.index_oid));
+    row.insert("conparentid".to_string(), json!(0));
+    row.insert("conkey".to_string(), json!(def.key_attnums));
+    row.insert("conislocal".to_string(), json!(true));
+    row.insert("coninhcount".to_string(), json!(0));
+    row.insert("connoinherit".to_string(), json!(false));
+    if is_foreign_key {
+        row.insert("confrelid".to_string(), json!(def.referenced_table_oid));
+        row.insert("confkey".to_string(), json!(def.referenced_key_attnums));
+        row.insert("confupdtype".to_string(), json!(def.on_update.code()));
+        row.insert("confdeltype".to_string(), json!(def.on_delete.code()));
+        row.insert("confmatchtype".to_string(), json!(def.match_type.code()));
+    } else {
+        row.insert("confrelid".to_string(), json!(0));
+        row.insert("confkey".to_string(), Value::Null);
+        row.insert("confupdtype".to_string(), json!(" "));
+        row.insert("confdeltype".to_string(), json!(" "));
+        row.insert("confmatchtype".to_string(), json!(" "));
+    }
+    row
+}
+
 /// Build one `pg_catalog.pg_type` row describing a relation's composite rowtype.
+///
+/// A composite type is variable-length and passed by reference (`typlen` -1,
+/// `typbyval` false), with the `record` I/O routines and extended storage that
+/// PostgreSQL uses for every relation rowtype. `typelem`/`typarray` are 0 (the
+/// rowtype is not an array element type and we do not register its array type).
 pub fn build_pg_type_rowtype_row(def: &RelationDef, namespace_oid: i32) -> Row {
     let mut row = Row::new();
     row.insert("oid".to_string(), json!(def.reltype_oid));
@@ -689,16 +1031,71 @@ pub fn build_pg_type_rowtype_row(def: &RelationDef, namespace_oid: i32) -> Row {
     row.insert("typlen".to_string(), json!(-1));
     row.insert("typtype".to_string(), json!("c"));
     row.insert("typcategory".to_string(), json!("C"));
+    // Physical/behavioral columns clients read for a composite type.
+    row.insert("typbyval".to_string(), json!(false));
+    row.insert("typalign".to_string(), json!("d"));
+    row.insert("typstorage".to_string(), json!("x"));
+    row.insert("typisdefined".to_string(), json!(true));
+    row.insert("typispreferred".to_string(), json!(false));
+    row.insert("typnotnull".to_string(), json!(false));
+    row.insert("typelem".to_string(), json!(0));
+    row.insert("typarray".to_string(), json!(0));
+    row.insert("typbasetype".to_string(), json!(0));
+    row.insert("typtypmod".to_string(), json!(-1));
+    row.insert("typndims".to_string(), json!(0));
+    row.insert("typinput".to_string(), json!("record_in"));
+    row.insert("typoutput".to_string(), json!("record_out"));
+    row.insert("typreceive".to_string(), json!("record_recv"));
+    row.insert("typsend".to_string(), json!("record_send"));
+    row.insert("typdelim".to_string(), json!(","));
     row
 }
 
+/// The physical storage attributes a `pg_type` OID implies for `pg_attribute`:
+/// `(attlen, attbyval, attalign, attstorage)`. Covers the common scalar types a
+/// user table exposes; unknown OIDs fall back to a variable-length,
+/// not-by-value, extended-storage column - the safe default for any text-like or
+/// composite type.
+fn column_type_storage(type_oid: i32) -> (i32, bool, &'static str, &'static str) {
+    match type_oid {
+        16 => (1, true, "c", "p"),                 // bool
+        18 => (1, true, "c", "p"),                 // "char"
+        21 => (2, true, "s", "p"),                 // int2
+        23 => (4, true, "i", "p"),                 // int4
+        26 => (4, true, "i", "p"),                 // oid
+        20 => (8, true, "d", "p"),                 // int8
+        700 => (4, true, "i", "p"),                // float4
+        701 => (8, true, "d", "p"),                // float8
+        1082 => (4, true, "i", "p"),               // date
+        1114 | 1184 => (8, true, "d", "p"),        // timestamp / timestamptz
+        1700 => (-1, false, "i", "m"),             // numeric (main-storage)
+        25 | 1042 | 1043 => (-1, false, "i", "x"), // text / bpchar / varchar
+        _ => (-1, false, "i", "x"),
+    }
+}
+
+/// The default collation OID a `pg_type` OID implies for `pg_attribute`: the
+/// collatable string types use the database default collation (100); every other
+/// type is non-collatable (0).
+fn column_collation(type_oid: i32) -> i32 {
+    match type_oid {
+        25 | 1042 | 1043 => 100, // text / bpchar / varchar -> default collation
+        _ => 0,
+    }
+}
+
 /// Build the `pg_catalog.pg_attribute` rows for a relation's columns. `attrelid`
-/// is the owning relation's OID; `attnum` is the 1-based ordinal position.
+/// is the owning relation's OID; `attnum` is the 1-based ordinal position. The
+/// physical columns clients read for the binary protocol and for column
+/// introspection (`attlen`/`attbyval`/`attalign`/`attstorage`/`attcollation`) are
+/// derived from each column's type OID; `atthasdef` reflects whether the column
+/// has a default (its `pg_attrdef` handle).
 pub fn build_pg_attribute_rows(attrelid: i32, columns: &[ColumnSpec]) -> Vec<Row> {
     columns
         .iter()
         .enumerate()
         .map(|(idx, col)| {
+            let (attlen, attbyval, attalign, attstorage) = column_type_storage(col.type_oid);
             let mut row = Row::new();
             row.insert("attrelid".to_string(), json!(attrelid));
             row.insert("attname".to_string(), json!(col.name));
@@ -706,10 +1103,49 @@ pub fn build_pg_attribute_rows(attrelid: i32, columns: &[ColumnSpec]) -> Vec<Row
             row.insert("attnum".to_string(), json!((idx + 1) as i32));
             row.insert("atttypmod".to_string(), json!(-1));
             row.insert("attnotnull".to_string(), json!(!col.nullable));
+            row.insert("atthasdef".to_string(), json!(col.has_default));
             row.insert("attisdropped".to_string(), json!(false));
+            // Physical layout, derived from the column's type.
+            row.insert("attlen".to_string(), json!(attlen));
+            row.insert("attbyval".to_string(), json!(attbyval));
+            row.insert("attalign".to_string(), json!(attalign));
+            row.insert("attstorage".to_string(), json!(attstorage));
+            row.insert("attcollation".to_string(), json!(column_collation(col.type_oid)));
+            // Fixed structural defaults for a plain, locally-defined column.
+            row.insert("attndims".to_string(), json!(0));
+            row.insert("attcacheoff".to_string(), json!(-1));
+            row.insert("attislocal".to_string(), json!(true));
+            row.insert("attinhcount".to_string(), json!(0));
+            row.insert("attstattarget".to_string(), json!(-1));
+            row.insert("attidentity".to_string(), json!(""));
+            row.insert("attgenerated".to_string(), json!(""));
+            row.insert("attcompression".to_string(), json!(""));
+            row.insert("atthasmissing".to_string(), json!(false));
             row
         })
         .collect()
+}
+
+/// Build one `pg_catalog.pg_attrdef` row marking that column `adnum` of relation
+/// `adrelid` has a default.
+///
+/// The compiled default expression (`adbin`, a node tree) is left NULL: we do not
+/// store node trees, and the human-facing default text is integration-supplied
+/// (Phase 2). This row, joined with `pg_attribute.atthasdef`, is the structural
+/// handle that `information_schema.columns` and clients read.
+/// Base OID for synthesized `pg_attrdef.oid` values on the lazy path. The column
+/// is NOT NULL in PostgreSQL but no consumer reads it (the constraint/column
+/// views join `pg_attrdef` on `adrelid`+`adnum`), so a high, unread range avoids
+/// colliding with real allocated OIDs.
+const SYNTHETIC_ATTRDEF_OID_BASE: i32 = 900_000;
+
+pub fn build_pg_attrdef_row(oid: i32, adrelid: i32, adnum: i32) -> Row {
+    let mut row = Row::new();
+    row.insert("oid".to_string(), json!(oid));
+    row.insert("adrelid".to_string(), json!(adrelid));
+    row.insert("adnum".to_string(), json!(adnum));
+    row.insert("adbin".to_string(), Value::Null);
+    row
 }
 
 /// Build one `information_schema.tables` row for a relation.
@@ -802,7 +1238,9 @@ pub fn build_rows_for(table: CatalogTable, source: &dyn LazyCatalogSource) -> DF
             for db in fetch_databases(source)? {
                 for schema in fetch_schemas(source, &db.datname)? {
                     for rel in fetch_relations(source, &db.datname, &schema.name)? {
-                        rows.push(build_pg_class_row(&rel, schema.oid));
+                        let natts =
+                            fetch_columns(source, &db.datname, &schema.name, &rel.name)?.len() as i32;
+                        rows.push(build_pg_class_row(&rel, schema.oid, natts));
                     }
                     // An index is itself a relation, so it gets its own pg_class
                     // row (relkind 'i') alongside the tables in this schema.
@@ -817,6 +1255,39 @@ pub fn build_rows_for(table: CatalogTable, source: &dyn LazyCatalogSource) -> DF
                 for schema in fetch_schemas(source, &db.datname)? {
                     for index in fetch_indexes(source, &db.datname, &schema.name)? {
                         rows.push(build_pg_index_row(&index));
+                    }
+                }
+            }
+        }
+        CatalogTable::PgConstraint => {
+            for db in fetch_databases(source)? {
+                for schema in fetch_schemas(source, &db.datname)? {
+                    for constraint in fetch_constraints(source, &db.datname, &schema.name)? {
+                        rows.push(build_pg_constraint_row(&constraint));
+                    }
+                }
+            }
+        }
+        CatalogTable::PgAttrdef => {
+            // One pg_attrdef row per column flagged as having a default. The OID
+            // is synthesized from a per-scan counter: nothing reads pg_attrdef.oid
+            // (consumers join on adrelid+adnum), so only stability within a scan
+            // matters, and the build order is deterministic.
+            let mut synthetic_oid = SYNTHETIC_ATTRDEF_OID_BASE;
+            for db in fetch_databases(source)? {
+                for schema in fetch_schemas(source, &db.datname)? {
+                    for rel in fetch_relations(source, &db.datname, &schema.name)? {
+                        let columns = fetch_columns(source, &db.datname, &schema.name, &rel.name)?;
+                        for (idx, col) in columns.iter().enumerate() {
+                            if col.has_default {
+                                rows.push(build_pg_attrdef_row(
+                                    synthetic_oid,
+                                    rel.oid,
+                                    (idx + 1) as i32,
+                                ));
+                                synthetic_oid += 1;
+                            }
+                        }
                     }
                 }
             }
@@ -1059,6 +1530,8 @@ impl LazyCatalogOptions {
                 CatalogTable::PgType,
                 CatalogTable::PgAttribute,
                 CatalogTable::PgIndex,
+                CatalogTable::PgConstraint,
+                CatalogTable::PgAttrdef,
                 CatalogTable::PgConfig,
                 CatalogTable::PgSettings,
                 CatalogTable::InformationSchemaTables,

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,6 +74,7 @@ async fn run() -> anyhow::Result<()> {
         ColumnDef {
             col_type: "int".to_string(),
             nullable: true,
+            has_default: false,
         },
     );
     let mut c2 = BTreeMap::new();
@@ -82,6 +83,7 @@ async fn run() -> anyhow::Result<()> {
         ColumnDef {
             col_type: "text".to_string(),
             nullable: true,
+            has_default: false,
         },
     );
     pg_catalog_helpers::register_user_tables(&ctx, "pgtry", "public", "users", vec![c1, c2])

--- a/src/pg_catalog_helpers.rs
+++ b/src/pg_catalog_helpers.rs
@@ -4,7 +4,12 @@ use datafusion::error::{DataFusionError, Result as DFResult};
 use datafusion::execution::context::SessionContext;
 use serde::Deserialize;
 
-use crate::lazy_catalog::{build_index_pg_class_row, build_pg_index_row, IndexDef};
+use crate::lazy_catalog::{
+    build_index_pg_class_row, build_info_columns_rows, build_info_tables_row,
+    build_pg_attrdef_row, build_pg_attribute_rows, build_pg_class_row, build_pg_constraint_row,
+    build_pg_index_row, build_pg_type_rowtype_row, ColumnSpec, ConstraintDef, ConstraintKind,
+    IndexDef, RelationDef,
+};
 use crate::session::rows_to_record_batch;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::atomic::{AtomicI32, Ordering};
@@ -17,6 +22,11 @@ pub struct ColumnDef {
     #[serde(rename = "type")]
     pub col_type: String,
     pub nullable: bool,
+    /// Whether the column has a default expression. Drives `pg_attribute.atthasdef`
+    /// and a `pg_attrdef` row; the default *text* is supplied later (Phase 2).
+    /// Defaults to false, so existing callers and wire payloads need not set it.
+    #[serde(default)]
+    pub has_default: bool,
 }
 
 static NEXT_OID: AtomicI32 = AtomicI32::new(50010);
@@ -57,11 +67,19 @@ fn take_schemas_from_registry(database_name: &str) -> Vec<String> {
         .unwrap_or_default()
 }
 
+/// Resolve a column's declared type string (as the integration writes it, e.g.
+/// `int`, `varchar(64)`, `text`) to its PostgreSQL `pg_type` OID. The OID is the
+/// single source of truth for both `pg_attribute.atttypid` and the
+/// `information_schema.columns` type names (via [`oid_to_type_names`]), so the
+/// two never disagree. Unrecognized types fall back to `text` (OID 25), the
+/// permissive default used across this module.
 pub(crate) fn map_type_to_oid(t: &str) -> i32 {
-    match t.to_lowercase().as_str() {
+    let lower = t.to_lowercase();
+    match lower.as_str() {
         "int" | "integer" | "int4" => 23,
         "bigint" | "int8" => 20,
         "bool" | "boolean" => 16,
+        other if other.starts_with("varchar") || other.starts_with("character varying") => 1043,
         _ => 25, // default to text
     }
 }
@@ -69,10 +87,10 @@ pub(crate) fn map_type_to_oid(t: &str) -> i32 {
 /// Map a PostgreSQL type OID back to its `(data_type, udt_name)` pair as used in
 /// `information_schema.columns`.
 ///
-/// This is the inverse of [`map_type_to_oid`] / [`normalize_data_type_name`] and
-/// lets the lazy catalog path render `information_schema.columns` rows when the
-/// source only hands us a `pg_type` OID for each column. Unknown OIDs fall back
-/// to `text`, mirroring the permissive default used elsewhere in this module.
+/// This is the inverse of [`map_type_to_oid`] and lets both the eager and lazy
+/// registration paths render `information_schema.columns` rows from a column's
+/// `pg_type` OID alone. Unknown OIDs fall back to `text`, mirroring the
+/// permissive default used elsewhere in this module.
 pub(crate) fn oid_to_type_names(oid: i32) -> (String, String) {
     match oid {
         23 => ("integer".to_string(), "int4".to_string()),
@@ -81,18 +99,6 @@ pub(crate) fn oid_to_type_names(oid: i32) -> (String, String) {
         1043 => ("character varying".to_string(), "varchar".to_string()),
         25 => ("text".to_string(), "text".to_string()),
         _ => ("text".to_string(), "text".to_string()),
-    }
-}
-
-pub(crate) fn normalize_data_type_name(t: &str) -> (String, String) {
-    let lower = t.to_lowercase();
-    match lower.as_str() {
-        "int" | "integer" | "int4" => ("integer".to_string(), "int4".to_string()),
-        "bigint" | "int8" => ("bigint".to_string(), "int8".to_string()),
-        "bool" | "boolean" => ("boolean".to_string(), "bool".to_string()),
-        s if s.starts_with("varchar") => ("character varying".to_string(), "varchar".to_string()),
-        "text" => ("text".to_string(), "text".to_string()),
-        _ => (lower.clone(), lower.clone()),
     }
 }
 
@@ -185,189 +191,122 @@ pub async fn register_schema(
     Ok(())
 }
 
+/// Convert the wire-format column descriptions (each a single-entry
+/// `name -> ColumnDef` map) into the `ColumnSpec` list the shared catalog
+/// row-builders consume, resolving each declared type string to its `pg_type`
+/// OID. A map with no entry is skipped.
+fn column_specs_from_defs(columns: &[BTreeMap<String, ColumnDef>]) -> Vec<ColumnSpec> {
+    columns
+        .iter()
+        .filter_map(|column| {
+            column.iter().next().map(|(name, def)| {
+                let spec = ColumnSpec::new(name.clone(), map_type_to_oid(&def.col_type), def.nullable);
+                if def.has_default {
+                    spec.with_default()
+                } else {
+                    spec
+                }
+            })
+        })
+        .collect()
+}
+
 pub async fn register_user_tables(
     ctx: &SessionContext,
-    _database_name: &str,
+    database_name: &str,
     schema_name: &str,
     table_name: &str,
     columns: Vec<BTreeMap<String, ColumnDef>>,
 ) -> DFResult<()> {
-    let df = ctx
+    // Idempotent: a relation already registered under this name is left as is.
+    let already_registered = ctx
         .sql("SELECT 1 FROM pg_catalog.pg_class WHERE relname=$relname")
         .await?
-        .with_param_values(vec![("relname", ScalarValue::from(table_name))])?;
-
-    if df.count().await? > 0 {
-        log::info!("table already exists {:}?", table_name);
+        .with_param_values(vec![("relname", ScalarValue::from(table_name))])?
+        .count()
+        .await?
+        > 0;
+    if already_registered {
+        log::info!("table already exists {table_name}?");
         return Ok(());
     }
 
-    let table_oid = NEXT_OID.fetch_add(1, Ordering::SeqCst);
-    let type_oid = NEXT_OID.fetch_add(1, Ordering::SeqCst);
-
-    let ns_df = ctx
-        .sql("SELECT oid FROM pg_catalog.pg_namespace WHERE nspname=$schema")
-        .await?
-        .with_param_values(vec![("schema", ScalarValue::from(schema_name))])?;
-    let ns_batches = ns_df.collect().await?;
-    let schema_oid = if ns_batches.is_empty() || ns_batches[0].num_rows() == 0 {
-        return Err(DataFusionError::Execution("schema not found".to_string()));
-    } else {
-        let arr = ns_batches[0]
-            .column(0)
-            .as_any()
-            .downcast_ref::<arrow::array::Int32Array>()
-            .unwrap();
-        arr.value(0)
+    let Some(schema_oid) = get_schema_oid(ctx, schema_name).await? else {
+        return Err(DataFusionError::Execution(format!(
+            "schema '{schema_name}' not found while registering table '{table_name}'"
+        )));
     };
 
-    if ctx
-        .sql(&format!(
-            "SELECT 1 FROM pg_catalog.pg_class WHERE oid = {table_oid}"
-        ))
-        .await?
-        .count()
-        .await?
-        == 0
-    {
-        let sql = format!(
-            "INSERT INTO pg_catalog.pg_class \
-                 (oid, relname, relnamespace, relkind, reltuples, reltype, relispartition) \
-                 VALUES ({table_oid},'{}',{schema_oid},'r',0,{type_oid}, false)",
-            table_name.replace('\'', "''")
-        );
-        ctx.sql(&sql).await?.collect().await?;
+    let table_oid = NEXT_OID.fetch_add(1, Ordering::SeqCst);
+    let type_oid = NEXT_OID.fetch_add(1, Ordering::SeqCst);
+    let column_specs = column_specs_from_defs(&columns);
+    let relation = RelationDef::table(table_oid, type_oid, table_name);
+
+    // pg_class identity row, its composite rowtype in pg_type, and one
+    // pg_attribute row per column - all from the same builders the lazy
+    // registration path uses, so eager and lazy emit identical rows.
+    append_catalog_row(
+        ctx,
+        "pg_catalog",
+        "pg_class",
+        build_pg_class_row(&relation, schema_oid, column_specs.len() as i32),
+    )
+    .await?;
+    append_catalog_row(
+        ctx,
+        "pg_catalog",
+        "pg_type",
+        build_pg_type_rowtype_row(&relation, schema_oid),
+    )
+    .await?;
+    for attribute_row in build_pg_attribute_rows(table_oid, &column_specs) {
+        append_catalog_row(ctx, "pg_catalog", "pg_attribute", attribute_row).await?;
     }
 
-    if ctx
-        .sql(&format!(
-            "SELECT 1 FROM pg_catalog.pg_type WHERE oid = {type_oid}"
-        ))
-        .await?
-        .count()
-        .await?
-        == 0
-    {
-        let sql = format!(
-            "INSERT INTO pg_catalog.pg_type \
-                 (oid, typname, typrelid, typlen, typcategory) \
-                 VALUES ({type_oid},'_{table_name}',{table_oid},-1,'C')"
-        );
-        ctx.sql(&sql).await?.collect().await?;
-    }
-
-    for (idx, col) in columns.iter().enumerate() {
-        let (name, def) = col.iter().next().unwrap();
-        let atttypid = map_type_to_oid(&def.col_type);
-        let notnull = if def.nullable { "false" } else { "true" };
-        let sql = format!(
-            "INSERT INTO pg_catalog.pg_attribute \
-                 (attrelid,attnum,attname,atttypid,atttypmod,attnotnull,attisdropped) \
-                 VALUES ({table_oid},{},'{}',{atttypid},-1,{notnull},false)",
-            idx + 1,
-            name.replace('\'', "''")
-        );
-        ctx.sql(&sql).await?.collect().await?;
-    }
-
-    // Also reflect the newly registered table in information_schema.tables.
-    // Insert only if a matching row doesn't already exist (idempotent).
-    let exists_df = ctx
-        .sql(
-            "SELECT 1 FROM information_schema.tables \
-             WHERE table_catalog=$cat AND table_schema=$sch AND table_name=$tbl",
-        )
-        .await?
-        .with_param_values(vec![
-            ("cat", ScalarValue::from(_database_name)),
-            ("sch", ScalarValue::from(schema_name)),
-            ("tbl", ScalarValue::from(table_name)),
-        ])?;
-    if exists_df.count().await? == 0 {
-        let insert_sql = format!(
-            "INSERT INTO information_schema.tables \
-             (table_catalog, table_schema, table_name, table_type, \
-              self_referencing_column_name, reference_generation, \
-              user_defined_type_catalog, user_defined_type_schema, user_defined_type_name, \
-              is_insertable_into, is_typed, commit_action) \
-             VALUES ('{}','{}','{}','BASE TABLE', \
-                     NULL, NULL, \
-                     NULL, NULL, NULL, \
-                     'YES','NO', NULL)",
-            _database_name.replace('\'', "''"),
-            schema_name.replace('\'', "''"),
-            table_name.replace('\'', "''"),
-        );
-        ctx.sql(&insert_sql).await?.collect().await?;
-    }
-
-    // Insert columns into information_schema.columns
-    for (idx, col) in columns.iter().enumerate() {
-        let (col_name, def) = col.iter().next().unwrap();
-        let (data_type, udt_name) = normalize_data_type_name(&def.col_type);
-        let is_nullable = if def.nullable { "YES" } else { "NO" };
-
-        let exists_df = ctx
-            .sql(
-                "SELECT 1 FROM information_schema.columns \
-                 WHERE table_catalog=$cat AND table_schema=$sch AND table_name=$tbl AND column_name=$col",
+    // One pg_attrdef row per column that has a default (its atthasdef flag is
+    // already set on the pg_attribute row above). The default text is supplied
+    // later (Phase 2); this is the structural handle clients join on.
+    for (idx, col) in column_specs.iter().enumerate() {
+        if col.has_default {
+            let adnum = (idx + 1) as i32;
+            let attrdef_oid = NEXT_OID.fetch_add(1, Ordering::SeqCst);
+            append_catalog_row(
+                ctx,
+                "pg_catalog",
+                "pg_attrdef",
+                build_pg_attrdef_row(attrdef_oid, table_oid, adnum),
             )
-            .await?
-            .with_param_values(vec![
-                ("cat", ScalarValue::from(_database_name)),
-                ("sch", ScalarValue::from(schema_name)),
-                ("tbl", ScalarValue::from(table_name)),
-                ("col", ScalarValue::from(col_name.as_str())),
-            ])?;
-        if exists_df.count().await? == 0 {
-            let insert_sql = format!(
-                "INSERT INTO information_schema.columns \
-                 (table_catalog, table_schema, table_name, column_name, ordinal_position, \
-                  column_default, is_nullable, data_type, \
-                  character_maximum_length, character_octet_length, numeric_precision, \
-                  numeric_precision_radix, numeric_scale, datetime_precision, interval_type, \
-                  interval_precision, character_set_catalog, character_set_schema, character_set_name, \
-                  collation_catalog, collation_schema, collation_name, domain_catalog, domain_schema, domain_name, \
-                  udt_catalog, udt_schema, udt_name, scope_catalog, scope_schema, scope_name, \
-                  maximum_cardinality, dtd_identifier, is_self_referencing, is_identity, identity_generation, \
-                  identity_start, identity_increment, identity_maximum, identity_minimum, identity_cycle, \
-                  is_generated, generation_expression, is_updatable) \
-                 VALUES ('{}','{}','{}','{}',{}, \
-                         NULL,'{}','{}', \
-                         NULL,NULL,NULL, \
-                         NULL,NULL,NULL,NULL, \
-                         NULL,NULL,NULL,NULL, \
-                         NULL,NULL,NULL,NULL,NULL, \
-                         NULL,'{}','pg_catalog','{}',NULL,NULL,NULL, \
-                         NULL,'{}','NO','NO',NULL, \
-                         NULL,NULL,NULL,NULL,'NO', \
-                         'NEVER',NULL,'YES')",
-                _database_name.replace('\'', "''"),
-                schema_name.replace('\'', "''"),
-                table_name.replace('\'', "''"),
-                col_name.replace('\'', "''"),
-                idx + 1,
-                is_nullable,
-                data_type,
-                _database_name.replace('\'', "''"),
-                udt_name,
-                (idx + 1).to_string(),
-            );
-            ctx.sql(&insert_sql).await?.collect().await?;
+            .await?;
         }
+    }
+
+    // Reflect the same relation in information_schema, where ORMs and BI tools
+    // read it - again via the shared builders rather than hand-written INSERTs.
+    append_catalog_row(
+        ctx,
+        "information_schema",
+        "tables",
+        build_info_tables_row(database_name, schema_name, &relation),
+    )
+    .await?;
+    for column_row in build_info_columns_rows(database_name, schema_name, table_name, &column_specs)
+    {
+        append_catalog_row(ctx, "information_schema", "columns", column_row).await?;
     }
 
     Ok(())
 }
 
-/// Append one row, built as a `column -> JSON value` map, to a `pg_catalog` table
-/// by materializing it against that table's Arrow schema and inserting it into
-/// the in-memory provider. Columns absent from `row` take their schema default
-/// (NULL). Used by the eager registration helpers to write rows whose columns
-/// include non-scalar types (e.g. the `pg_index.indkey` list) that a literal
-/// `INSERT ... VALUES` clause cannot express.
+/// Append one row, built as a `column -> JSON value` map, to a catalog table in
+/// the given schema (`pg_catalog` or `information_schema`) by materializing it
+/// against that table's Arrow schema and inserting it into the in-memory
+/// provider. Columns absent from `row` take their schema default (NULL). Used by
+/// the eager registration helpers to write rows whose columns include non-scalar
+/// types (e.g. the `pg_index.indkey` list) that a literal `INSERT ... VALUES`
+/// clause cannot express.
 async fn append_catalog_row(
     ctx: &SessionContext,
+    schema_name: &str,
     table_name: &str,
     row: BTreeMap<String, serde_json::Value>,
 ) -> DFResult<()> {
@@ -378,11 +317,11 @@ async fn append_catalog_row(
     let catalog = ctx.catalog(&default_catalog).ok_or_else(|| {
         DataFusionError::Execution(format!("default catalog '{default_catalog}' not found"))
     })?;
-    let schema_provider = catalog
-        .schema("pg_catalog")
-        .ok_or_else(|| DataFusionError::Execution("schema 'pg_catalog' not found".to_string()))?;
+    let schema_provider = catalog.schema(schema_name).ok_or_else(|| {
+        DataFusionError::Execution(format!("schema '{schema_name}' not found"))
+    })?;
     let provider = schema_provider.table(table_name).await?.ok_or_else(|| {
-        DataFusionError::Execution(format!("table 'pg_catalog.{table_name}' not found"))
+        DataFusionError::Execution(format!("table '{schema_name}.{table_name}' not found"))
     })?;
     let schema = provider.schema();
     let batch = rows_to_record_batch(&schema, &[row])?;
@@ -391,11 +330,11 @@ async fn append_catalog_row(
     // catalog table so its columns are matched by the schema rather than by a
     // literal VALUES tuple. The staging table is dropped whether the insert
     // succeeds or fails.
-    let staging_table = format!("__pg_catalog_append_{table_name}");
+    let staging_table = format!("__catalog_append_{schema_name}_{table_name}");
     ctx.register_batch(&staging_table, batch)?;
     let inserted = ctx
         .sql(&format!(
-            "INSERT INTO pg_catalog.{table_name} SELECT * FROM {staging_table}"
+            "INSERT INTO {schema_name}.{table_name} SELECT * FROM {staging_table}"
         ))
         .await;
     let inserted = match inserted {
@@ -455,11 +394,116 @@ pub async fn register_user_index(
 
     append_catalog_row(
         ctx,
+        "pg_catalog",
         "pg_class",
         build_index_pg_class_row(&index_def, schema_oid),
     )
     .await?;
-    append_catalog_row(ctx, "pg_index", build_pg_index_row(&index_def)).await?;
+    append_catalog_row(ctx, "pg_catalog", "pg_index", build_pg_index_row(&index_def)).await?;
+
+    Ok(())
+}
+
+/// Pre-register one constraint (primary key, unique, or foreign key) for an
+/// existing user table, the constraint analogue of [`register_user_index`]. It
+/// writes one `pg_catalog.pg_constraint` row, which the `information_schema`
+/// constraint views (`table_constraints`, `key_column_usage`,
+/// `constraint_column_usage`, `referential_constraints`) derive from.
+///
+/// `key_attnums` are the constrained columns' 1-based attnums. For a foreign key,
+/// `referenced_table_name` names the target table within `schema_name` and
+/// `referenced_key_attnums` its referenced columns (positionally matched to
+/// `key_attnums`); both are ignored for primary-key and unique constraints. The
+/// call is idempotent: a constraint of the same name already on the table is left
+/// untouched.
+#[allow(clippy::too_many_arguments)]
+pub async fn register_user_constraint(
+    ctx: &SessionContext,
+    schema_name: &str,
+    constraint_name: &str,
+    table_name: &str,
+    kind: ConstraintKind,
+    key_attnums: Vec<i32>,
+    referenced_table_name: Option<&str>,
+    referenced_key_attnums: Vec<i32>,
+) -> DFResult<()> {
+    let Some(schema_oid) = get_schema_oid(ctx, schema_name).await? else {
+        return Err(DataFusionError::Execution(format!(
+            "schema '{schema_name}' not found while registering constraint '{constraint_name}'"
+        )));
+    };
+    let Some(table_oid) = get_table_oid(ctx, schema_oid, table_name).await? else {
+        return Err(DataFusionError::Execution(format!(
+            "table '{schema_name}.{table_name}' not found while registering constraint '{constraint_name}'"
+        )));
+    };
+
+    let already_registered = ctx
+        .sql(&format!(
+            "SELECT 1 FROM pg_catalog.pg_constraint \
+             WHERE conname = $conname AND conrelid = {table_oid}"
+        ))
+        .await?
+        .with_param_values(vec![("conname", ScalarValue::from(constraint_name))])?
+        .count()
+        .await?
+        > 0;
+    if already_registered {
+        log::info!("constraint already exists {constraint_name}?");
+        return Ok(());
+    }
+
+    let constraint_oid = NEXT_OID.fetch_add(1, Ordering::SeqCst);
+    let constraint = match kind {
+        ConstraintKind::ForeignKey => {
+            let Some(referenced_table) = referenced_table_name else {
+                return Err(DataFusionError::Execution(format!(
+                    "foreign key '{constraint_name}' requires a referenced table name"
+                )));
+            };
+            let Some(referenced_oid) = get_table_oid(ctx, schema_oid, referenced_table).await?
+            else {
+                return Err(DataFusionError::Execution(format!(
+                    "referenced table '{schema_name}.{referenced_table}' not found \
+                     while registering foreign key '{constraint_name}'"
+                )));
+            };
+            ConstraintDef::foreign_key(
+                constraint_oid,
+                constraint_name,
+                schema_oid,
+                table_oid,
+                key_attnums,
+                referenced_oid,
+                referenced_key_attnums,
+                0,
+            )
+        }
+        ConstraintKind::PrimaryKey => ConstraintDef::primary_key(
+            constraint_oid,
+            constraint_name,
+            schema_oid,
+            table_oid,
+            key_attnums,
+            0,
+        ),
+        ConstraintKind::Unique => ConstraintDef::unique(
+            constraint_oid,
+            constraint_name,
+            schema_oid,
+            table_oid,
+            key_attnums,
+            0,
+        ),
+    };
+
+    append_catalog_row(
+        ctx,
+        "pg_catalog",
+        "pg_constraint",
+        build_pg_constraint_row(&constraint),
+    )
+    .await?;
 
     Ok(())
 }
@@ -668,6 +712,7 @@ mod tests {
             ColumnDef {
                 col_type: "int".to_string(),
                 nullable: true,
+                has_default: false,
             },
         );
         let mut c2 = BTreeMap::new();
@@ -676,6 +721,7 @@ mod tests {
             ColumnDef {
                 col_type: "text".to_string(),
                 nullable: true,
+                has_default: false,
             },
         );
 
@@ -728,6 +774,7 @@ mod tests {
             ColumnDef {
                 col_type: "int".to_string(),
                 nullable: false,
+                has_default: false,
             },
         );
         register_user_tables(&ctx, "pgtry", "myschema", "contacts", vec![c1]).await?;
@@ -796,6 +843,264 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_register_user_constraint_dynamic() -> DFResult<()> {
+        let (ctx, _) = get_base_session_context(
+            Some("pg_catalog_data/pg_schema"),
+            "pgtry".to_string(),
+            "public".to_string(),
+            None,
+        )
+        .await?;
+
+        register_schema(&ctx, "pgtry", "myschema").await?;
+
+        // Parent table 'users' (id, email) and child 'orders' (id, user_id).
+        let mut users_id = BTreeMap::new();
+        users_id.insert(
+            "id".to_string(),
+            ColumnDef {
+                col_type: "int".to_string(),
+                nullable: false,
+                has_default: false,
+            },
+        );
+        let mut users_email = BTreeMap::new();
+        users_email.insert(
+            "email".to_string(),
+            ColumnDef {
+                col_type: "text".to_string(),
+                nullable: false,
+                has_default: false,
+            },
+        );
+        register_user_tables(
+            &ctx,
+            "pgtry",
+            "myschema",
+            "users",
+            vec![users_id, users_email],
+        )
+        .await?;
+
+        let mut orders_id = BTreeMap::new();
+        orders_id.insert(
+            "id".to_string(),
+            ColumnDef {
+                col_type: "int".to_string(),
+                nullable: false,
+                has_default: false,
+            },
+        );
+        let mut orders_user_id = BTreeMap::new();
+        orders_user_id.insert(
+            "user_id".to_string(),
+            ColumnDef {
+                col_type: "int".to_string(),
+                nullable: false,
+                has_default: false,
+            },
+        );
+        register_user_tables(
+            &ctx,
+            "pgtry",
+            "myschema",
+            "orders",
+            vec![orders_id, orders_user_id],
+        )
+        .await?;
+
+        // A primary key and a unique constraint on 'users', and a foreign key
+        // from orders.user_id -> users.id.
+        register_user_constraint(
+            &ctx,
+            "myschema",
+            "users_pkey",
+            "users",
+            ConstraintKind::PrimaryKey,
+            vec![1],
+            None,
+            vec![],
+        )
+        .await?;
+        register_user_constraint(
+            &ctx,
+            "myschema",
+            "users_email_key",
+            "users",
+            ConstraintKind::Unique,
+            vec![2],
+            None,
+            vec![],
+        )
+        .await?;
+        register_user_constraint(
+            &ctx,
+            "myschema",
+            "orders_user_id_fkey",
+            "orders",
+            ConstraintKind::ForeignKey,
+            vec![2],
+            Some("users"),
+            vec![1],
+        )
+        .await?;
+
+        // The primary key carries contype 'p' over the right table and column.
+        let df = ctx
+            .sql(
+                "SELECT c.contype FROM pg_catalog.pg_constraint c \
+                 JOIN pg_catalog.pg_class t ON t.oid = c.conrelid \
+                 WHERE c.conname = 'users_pkey' AND t.relname = 'users' \
+                 AND c.contype = 'p' AND c.conkey = [1]",
+            )
+            .await?;
+        assert_eq!(df.count().await?, 1, "primary key row must be present");
+
+        // The unique constraint targets the second column.
+        let df = ctx
+            .sql(
+                "SELECT 1 FROM pg_catalog.pg_constraint \
+                 WHERE conname = 'users_email_key' AND contype = 'u' AND conkey = [2]",
+            )
+            .await?;
+        assert_eq!(df.count().await?, 1, "unique constraint row must be present");
+
+        // The foreign key points at the parent table and column, with NO ACTION
+        // ('a') update/delete rules.
+        let df = ctx
+            .sql(
+                "SELECT 1 FROM pg_catalog.pg_constraint fk \
+                 JOIN pg_catalog.pg_class parent ON parent.oid = fk.confrelid \
+                 WHERE fk.conname = 'orders_user_id_fkey' AND fk.contype = 'f' \
+                 AND parent.relname = 'users' AND fk.confkey = [1] \
+                 AND fk.confupdtype = 'a' AND fk.confdeltype = 'a'",
+            )
+            .await?;
+        assert_eq!(df.count().await?, 1, "foreign key row must reference users");
+
+        // Re-registering the same constraint is a no-op (still one row).
+        register_user_constraint(
+            &ctx,
+            "myschema",
+            "users_pkey",
+            "users",
+            ConstraintKind::PrimaryKey,
+            vec![1],
+            None,
+            vec![],
+        )
+        .await?;
+        let df = ctx
+            .sql("SELECT 1 FROM pg_catalog.pg_constraint WHERE conname = 'users_pkey'")
+            .await?;
+        assert_eq!(df.count().await?, 1, "constraint registration is idempotent");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_register_user_columns_fidelity_and_attrdef() -> DFResult<()> {
+        let (ctx, _) = get_base_session_context(
+            Some("pg_catalog_data/pg_schema"),
+            "pgtry".to_string(),
+            "public".to_string(),
+            None,
+        )
+        .await?;
+
+        register_schema(&ctx, "pgtry", "myschema").await?;
+
+        // 'id' int (no default), 'label' text (no default), 'created' bigint with
+        // a default expression.
+        let mut id = BTreeMap::new();
+        id.insert(
+            "id".to_string(),
+            ColumnDef {
+                col_type: "int".to_string(),
+                nullable: false,
+                has_default: false,
+            },
+        );
+        let mut label = BTreeMap::new();
+        label.insert(
+            "label".to_string(),
+            ColumnDef {
+                col_type: "text".to_string(),
+                nullable: true,
+                has_default: false,
+            },
+        );
+        let mut created = BTreeMap::new();
+        created.insert(
+            "created".to_string(),
+            ColumnDef {
+                col_type: "bigint".to_string(),
+                nullable: false,
+                has_default: true,
+            },
+        );
+        register_user_tables(&ctx, "pgtry", "myschema", "widgets", vec![id, label, created]).await?;
+
+        // pg_class records the column count and the heap access method.
+        let df = ctx
+            .sql(
+                "SELECT 1 FROM pg_catalog.pg_class \
+                 WHERE relname = 'widgets' AND relnatts = 3 AND relam = 2",
+            )
+            .await?;
+        assert_eq!(df.count().await?, 1, "pg_class relnatts/relam must be filled");
+
+        // The int column has fixed 4-byte, by-value, int-aligned storage.
+        let df = ctx
+            .sql(
+                "SELECT 1 FROM pg_catalog.pg_attribute \
+                 WHERE attrelid = (SELECT oid FROM pg_catalog.pg_class WHERE relname = 'widgets') \
+                 AND attname = 'id' AND attlen = 4 AND attbyval = true AND attalign = 'i'",
+            )
+            .await?;
+        assert_eq!(df.count().await?, 1, "int4 storage attributes must be derived");
+
+        // The text column is variable-length, extended storage, default collation.
+        let df = ctx
+            .sql(
+                "SELECT 1 FROM pg_catalog.pg_attribute \
+                 WHERE attrelid = (SELECT oid FROM pg_catalog.pg_class WHERE relname = 'widgets') \
+                 AND attname = 'label' AND attlen = -1 AND attbyval = false \
+                 AND attstorage = 'x' AND attcollation = 100",
+            )
+            .await?;
+        assert_eq!(df.count().await?, 1, "text storage attributes must be derived");
+
+        // The defaulted column carries atthasdef and a backing pg_attrdef row.
+        let df = ctx
+            .sql(
+                "SELECT 1 FROM pg_catalog.pg_attribute \
+                 WHERE attrelid = (SELECT oid FROM pg_catalog.pg_class WHERE relname = 'widgets') \
+                 AND attname = 'created' AND atthasdef = true",
+            )
+            .await?;
+        assert_eq!(df.count().await?, 1, "defaulted column must set atthasdef");
+        let df = ctx
+            .sql(
+                "SELECT 1 FROM pg_catalog.pg_attrdef \
+                 WHERE adrelid = (SELECT oid FROM pg_catalog.pg_class WHERE relname = 'widgets') \
+                 AND adnum = 3",
+            )
+            .await?;
+        assert_eq!(df.count().await?, 1, "defaulted column must get a pg_attrdef row");
+
+        // A column without a default has neither atthasdef nor a pg_attrdef row.
+        let df = ctx
+            .sql(
+                "SELECT 1 FROM pg_catalog.pg_attrdef \
+                 WHERE adrelid = (SELECT oid FROM pg_catalog.pg_class WHERE relname = 'widgets') \
+                 AND adnum = 1",
+            )
+            .await?;
+        assert_eq!(df.count().await?, 0, "a column with no default has no pg_attrdef row");
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_register_user_tables_information_schema() -> DFResult<()> {
         let (ctx, _) = get_base_session_context(
             Some("pg_catalog_data/pg_schema"),
@@ -813,6 +1118,7 @@ mod tests {
             ColumnDef {
                 col_type: "int".to_string(),
                 nullable: true,
+                has_default: false,
             },
         );
         let mut c2 = BTreeMap::new();
@@ -821,6 +1127,7 @@ mod tests {
             ColumnDef {
                 col_type: "text".to_string(),
                 nullable: true,
+                has_default: false,
             },
         );
 
@@ -898,6 +1205,7 @@ mod tests {
             ColumnDef {
                 col_type: "int".to_string(),
                 nullable: true,
+                has_default: false,
             },
         );
         let mut c2 = BTreeMap::new();
@@ -906,6 +1214,7 @@ mod tests {
             ColumnDef {
                 col_type: "text".to_string(),
                 nullable: true,
+                has_default: false,
             },
         );
 
@@ -1003,6 +1312,7 @@ mod tests {
             ColumnDef {
                 col_type: "int".to_string(),
                 nullable: true,
+                has_default: false,
             },
         );
         let mut c2 = BTreeMap::new();
@@ -1011,6 +1321,7 @@ mod tests {
             ColumnDef {
                 col_type: "text".to_string(),
                 nullable: true,
+                has_default: false,
             },
         );
 
@@ -1098,6 +1409,7 @@ mod tests {
             ColumnDef {
                 col_type: "int".to_string(),
                 nullable: false,
+                has_default: false,
             },
         );
         register_user_tables(&ctx, "pgtry", "myschema", "contacts", vec![c1]).await?;
@@ -1143,6 +1455,7 @@ mod tests {
             ColumnDef {
                 col_type: "int".to_string(),
                 nullable: false,
+                has_default: false,
             },
         );
         register_user_tables(&ctx, "pgtry", "myschema", "contacts", vec![c1]).await?;
@@ -1181,6 +1494,7 @@ mod tests {
             ColumnDef {
                 col_type: "int".to_string(),
                 nullable: false,
+                has_default: false,
             },
         );
         register_user_tables(&ctx, "crm", "crm_schema", "contacts", vec![c1]).await?;

--- a/src/session.rs
+++ b/src/session.rs
@@ -179,8 +179,16 @@ struct ViewToRegister {
     sql: String,
 }
 
-const VIEW_ONLY_TABLES: &[(&str, &str)] =
-    &[("pg_catalog", "pg_views"), ("pg_catalog", "pg_tables")];
+const VIEW_ONLY_TABLES: &[(&str, &str)] = &[
+    ("pg_catalog", "pg_views"),
+    ("pg_catalog", "pg_tables"),
+    // Constraint views served live so they reflect runtime-registered user
+    // constraints (pg_constraint) rather than the frozen seed snapshot.
+    ("information_schema", "table_constraints"),
+    ("information_schema", "key_column_usage"),
+    ("information_schema", "constraint_column_usage"),
+    ("information_schema", "referential_constraints"),
+];
 
 fn should_register_as_view(schema_name: &str, table_name: &str) -> bool {
     VIEW_ONLY_TABLES
@@ -211,6 +219,20 @@ fn normalize_view_sql(sql: &str) -> String {
     let trimmed = sql.trim();
     let without_semicolon = trimmed.trim_end_matches(';').trim();
     without_semicolon.to_string()
+}
+
+/// Replace `current_database()` calls in a catalog view body with `catalog` as a
+/// string literal.
+///
+/// A live view is planned eagerly at session setup (`CREATE VIEW`), but
+/// `current_database()` is a per-connection UDF registered only once a client
+/// connects, so it is unresolved at setup time. In this single-catalog layer the
+/// current database is always the default catalog, so substituting its name as a
+/// literal is both sufficient and correct - and confines the dependency to view
+/// creation rather than requiring the connection-scoped UDF up front.
+fn inline_current_database(sql: &str, catalog: &str) -> String {
+    let literal = format!("'{}'", catalog.replace('\'', "''"));
+    sql.replace("current_database()", &literal)
 }
 
 async fn set_default_schema(ctx: &SessionContext, schema: &str) -> datafusion::error::Result<()> {
@@ -1085,13 +1107,22 @@ async fn create_registered_views(
 
     let state = ctx.state();
     let original_default_schema = state.config_options().catalog.default_schema.clone();
+    let default_catalog = state.config_options().catalog.default_catalog.clone();
     drop(state);
+
+    // Catalog view bodies reference their base tables (pg_class, pg_attribute,
+    // pg_constraint, ...) unqualified, and those all live in pg_catalog - so
+    // resolve every view body under pg_catalog regardless of which schema the
+    // view itself belongs to. The CREATE statement below is fully schema-
+    // qualified, so each view still lands in its own schema (e.g.
+    // information_schema.table_constraints).
+    const VIEW_BODY_RESOLUTION_SCHEMA: &str = "pg_catalog";
     let mut active_default_schema = original_default_schema.clone();
 
     for view in views {
-        if active_default_schema != view.schema {
-            set_default_schema(ctx, &view.schema).await?;
-            active_default_schema = view.schema.clone();
+        if active_default_schema != VIEW_BODY_RESOLUTION_SCHEMA {
+            set_default_schema(ctx, VIEW_BODY_RESOLUTION_SCHEMA).await?;
+            active_default_schema = VIEW_BODY_RESOLUTION_SCHEMA.to_string();
         }
 
         let qualified = format_fully_qualified_name(&view.catalog, &view.schema, &view.name);
@@ -1104,7 +1135,8 @@ async fn create_registered_views(
         }
 
         let rewritten_select = {
-            let rewritten = rewrite_srf_to_unnest(&definition)?;
+            let inlined = inline_current_database(&definition, &default_catalog);
+            let rewritten = rewrite_srf_to_unnest(&inlined)?;
             let (rewritten, _) = rewrite_filters(&rewritten)?;
             let rewritten = rewrite_exists_to_count(&rewritten)?;
             rewrite_tuple_in_subquery_to_exists(&rewritten)?

--- a/src/user_functions.rs
+++ b/src/user_functions.rs
@@ -3104,33 +3104,353 @@ pub fn register_pg_get_function_arguments(ctx: &SessionContext) -> Result<()> {
     Ok(())
 }
 
-/// pg_catalog.pg_get_indexdef(oid) -> text
-pub fn register_pg_get_indexdef(ctx: &SessionContext) -> Result<()> {
-    use arrow::array::{ArrayRef, StringBuilder};
-    use arrow::datatypes::DataType;
-    use datafusion::logical_expr::{create_udf, ColumnarValue, Volatility};
-    use std::sync::Arc;
-
-    let fun = |args: &[ColumnarValue]| -> Result<ColumnarValue> {
-        let len = match args.first() {
-            Some(ColumnarValue::Array(a)) => a.len(),
-            _ => 1,
-        };
-        let mut b = StringBuilder::with_capacity(len, len);
-        for _ in 0..len {
-            b.append_null();
-        }
-        Ok(ColumnarValue::Array(Arc::new(b.finish()) as ArrayRef))
-    };
-
-    let udf = create_udf(
-        "pg_catalog.pg_get_indexdef",
-        vec![DataType::Int64],
-        DataType::Utf8,
-        Volatility::Stable,
-        Arc::new(fun),
+/// Render the canonical `CREATE INDEX` statement for a plain (non-expression)
+/// index, matching PostgreSQL's `pg_get_indexdef` output.
+///
+/// `columns` are the indexed column names in index-key order. The table is
+/// always schema-qualified, e.g.
+/// `CREATE UNIQUE INDEX foo_pkey ON public.foo USING btree (a, b)`.
+fn render_create_index_statement(
+    is_unique: bool,
+    index_name: &str,
+    schema_name: &str,
+    table_name: &str,
+    access_method: &str,
+    columns: &[String],
+) -> String {
+    let unique = if is_unique { "UNIQUE " } else { "" };
+    format!(
+        "CREATE {unique}INDEX {index_name} ON {schema_name}.{table_name} USING {access_method} ({})",
+        columns.join(", ")
     )
-    .with_aliases(["pg_get_indexdef"]);
+}
+
+/// The structural parts of one index, read from the catalog, that a plain
+/// `CREATE INDEX` statement is templated from. `key_attnums` are the indexed
+/// columns' attribute numbers in key order; a `0` marks an expression column,
+/// which makes the index functional/partial (its text is integration-supplied
+/// in Phase 2, not rendered here).
+struct PlainIndexParts {
+    index_oid: i64,
+    table_oid: i64,
+    is_unique: bool,
+    key_attnums: Vec<i64>,
+    index_name: String,
+    table_name: String,
+    schema_name: String,
+    access_method: String,
+}
+
+/// Resolve a set of index OIDs to their `CREATE INDEX` text with a fixed, small
+/// number of UDF-free catalog queries (one for the index/table/access-method
+/// parts, one for the column names). Indexes whose key includes an expression
+/// (attnum `0`), and any whose parts cannot be fully resolved, are omitted from
+/// the map so the caller renders SQL NULL for them.
+fn fetch_index_definitions(ctx: Arc<SessionContext>, oids: &[i64]) -> Result<HashMap<i64, String>> {
+    let mut out: HashMap<i64, String> = HashMap::new();
+    if oids.is_empty() {
+        return Ok(out);
+    }
+
+    let in_list = oids
+        .iter()
+        .map(|o| o.to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    run_catalog_query(async move {
+        // One row per index: name, owning table + schema, access method,
+        // uniqueness and the key-column attnums (indkey is an int2vector list).
+        let parts_sql = format!(
+            "SELECT x.indexrelid, x.indrelid, x.indisunique, x.indkey, \
+                    i.relname AS indexname, c.relname AS tablename, \
+                    n.nspname AS schemaname, am.amname \
+             FROM pg_catalog.pg_index x \
+             JOIN pg_catalog.pg_class i ON i.oid = x.indexrelid \
+             JOIN pg_catalog.pg_class c ON c.oid = x.indrelid \
+             JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace \
+             JOIN pg_catalog.pg_am am ON am.oid = i.relam \
+             WHERE x.indexrelid IN ({in_list})"
+        );
+        let part_batches = ctx.sql(&parts_sql).await?.collect().await?;
+
+        let mut parsed: Vec<PlainIndexParts> = Vec::new();
+        for batch in &part_batches {
+            for row in 0..batch.num_rows() {
+                let index_oid = match column_oid_at(batch, "indexrelid", row)? {
+                    Some(v) => v,
+                    None => continue,
+                };
+                let table_oid = match column_oid_at(batch, "indrelid", row)? {
+                    Some(v) => v,
+                    None => continue,
+                };
+                let key_attnums = match index_key_attnums_at(batch, "indkey", row)? {
+                    Some(v) => v,
+                    None => continue,
+                };
+                let (index_name, table_name, schema_name, access_method) = (
+                    column_string_at(batch, "indexname", row)?,
+                    column_string_at(batch, "tablename", row)?,
+                    column_string_at(batch, "schemaname", row)?,
+                    column_string_at(batch, "amname", row)?,
+                );
+                let (Some(index_name), Some(table_name), Some(schema_name), Some(access_method)) =
+                    (index_name, table_name, schema_name, access_method)
+                else {
+                    continue;
+                };
+                parsed.push(PlainIndexParts {
+                    index_oid,
+                    table_oid,
+                    is_unique: column_bool_at(batch, "indisunique", row)?.unwrap_or(false),
+                    key_attnums,
+                    index_name,
+                    table_name,
+                    schema_name,
+                    access_method,
+                });
+            }
+        }
+
+        // Map each (table oid, attnum) to its column name in one query over the
+        // distinct owning tables.
+        let mut table_oids: Vec<i64> = parsed.iter().map(|p| p.table_oid).collect();
+        table_oids.sort_unstable();
+        table_oids.dedup();
+        let names = fetch_attribute_names(ctx.clone(), &table_oids).await?;
+
+        for index in parsed {
+            // An expression key column (attnum 0) means a functional/partial
+            // index; leave its text NULL for Phase 2.
+            if index.key_attnums.iter().any(|&attnum| attnum == 0) {
+                continue;
+            }
+            let mut columns: Vec<String> = Vec::with_capacity(index.key_attnums.len());
+            let mut resolvable = true;
+            for attnum in &index.key_attnums {
+                match names.get(&(index.table_oid, *attnum)) {
+                    Some(name) => columns.push(name.clone()),
+                    None => {
+                        resolvable = false;
+                        break;
+                    }
+                }
+            }
+            if !resolvable {
+                continue;
+            }
+            out.insert(
+                index.index_oid,
+                render_create_index_statement(
+                    index.is_unique,
+                    &index.index_name,
+                    &index.schema_name,
+                    &index.table_name,
+                    &index.access_method,
+                    &columns,
+                ),
+            );
+        }
+
+        Ok::<_, DataFusionError>(out)
+    })
+}
+
+/// Resolve `(attrelid, attnum) -> attname` for the given relations with a single
+/// catalog query. Dropped and system (attnum <= 0) columns are excluded, since
+/// an index key only references real, ordinary columns.
+async fn fetch_attribute_names(
+    ctx: Arc<SessionContext>,
+    table_oids: &[i64],
+) -> Result<HashMap<(i64, i64), String>> {
+    let mut out: HashMap<(i64, i64), String> = HashMap::new();
+    if table_oids.is_empty() {
+        return Ok(out);
+    }
+    let in_list = table_oids
+        .iter()
+        .map(|o| o.to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let sql = format!(
+        "SELECT attrelid, attnum, attname FROM pg_catalog.pg_attribute \
+         WHERE attrelid IN ({in_list}) AND attnum > 0 AND attisdropped = false"
+    );
+    let batches = ctx.sql(&sql).await?.collect().await?;
+    for batch in &batches {
+        for row in 0..batch.num_rows() {
+            let (Some(attrelid), Some(attnum), Some(attname)) = (
+                column_oid_at(batch, "attrelid", row)?,
+                column_oid_at(batch, "attnum", row)?,
+                column_string_at(batch, "attname", row)?,
+            ) else {
+                continue;
+            };
+            out.insert((attrelid, attnum), attname);
+        }
+    }
+    Ok(out)
+}
+
+/// Read an integer/OID cell from `batch[column][row]`, widening any signed or
+/// unsigned 32/64-bit integer to `i64`. Returns `None` for NULL.
+fn column_oid_at(batch: &RecordBatch, column: &str, row: usize) -> Result<Option<i64>> {
+    let array = batch.column_by_name(column).ok_or_else(|| {
+        DataFusionError::Execution(format!("catalog query result missing column {column}"))
+    })?;
+    oid_at(array, row)
+}
+
+/// Read a UTF-8 cell from `batch[column][row]`. Returns `None` for NULL or a
+/// non-string column.
+fn column_string_at(batch: &RecordBatch, column: &str, row: usize) -> Result<Option<String>> {
+    let array = batch.column_by_name(column).ok_or_else(|| {
+        DataFusionError::Execution(format!("catalog query result missing column {column}"))
+    })?;
+    let scalar = ScalarValue::try_from_array(array, row)?;
+    Ok(match scalar {
+        ScalarValue::Utf8(v) | ScalarValue::LargeUtf8(v) | ScalarValue::Utf8View(v) => v,
+        _ => None,
+    })
+}
+
+/// Read a boolean cell from `batch[column][row]`. Returns `None` for NULL or a
+/// non-boolean column.
+fn column_bool_at(batch: &RecordBatch, column: &str, row: usize) -> Result<Option<bool>> {
+    let array = batch.column_by_name(column).ok_or_else(|| {
+        DataFusionError::Execution(format!("catalog query result missing column {column}"))
+    })?;
+    Ok(match ScalarValue::try_from_array(array, row)? {
+        ScalarValue::Boolean(v) => v,
+        _ => None,
+    })
+}
+
+/// Read an `int2vector`-shaped list cell (e.g. `pg_index.indkey`) from
+/// `batch[column][row]` as the contained attribute numbers. Returns `None` for a
+/// NULL cell or a non-list column.
+fn index_key_attnums_at(batch: &RecordBatch, column: &str, row: usize) -> Result<Option<Vec<i64>>> {
+    let array = batch.column_by_name(column).ok_or_else(|| {
+        DataFusionError::Execution(format!("catalog query result missing column {column}"))
+    })?;
+    let list = match array.as_any().downcast_ref::<arrow::array::ListArray>() {
+        Some(list) => list,
+        None => return Ok(None),
+    };
+    if list.is_null(row) {
+        return Ok(None);
+    }
+    let element = list.value(row);
+    let mut attnums = Vec::with_capacity(element.len());
+    for i in 0..element.len() {
+        attnums.push(oid_at(&element, i)?.unwrap_or(0));
+    }
+    Ok(Some(attnums))
+}
+
+/// `pg_catalog.pg_get_indexdef(oid)` reconstructs the `CREATE INDEX` text for a
+/// plain index from the live catalog at call time, mirroring
+/// [`PgGetUserById`]'s batched catalog-lookup pattern. Functional/partial index
+/// expressions are left NULL pending Phase 2's integration-supplied text.
+struct PgGetIndexDef {
+    sig: Signature,
+    ctx: Arc<SessionContext>,
+}
+
+impl PgGetIndexDef {
+    /// Build the UDF over a clone of the session context it queries the catalog
+    /// through, accepting any signed/unsigned 32/64-bit OID argument.
+    fn new(ctx: Arc<SessionContext>) -> Self {
+        Self {
+            sig: Signature::one_of(
+                vec![
+                    TypeSignature::Exact(vec![ArrowDataType::Int32]),
+                    TypeSignature::Exact(vec![ArrowDataType::Int64]),
+                    TypeSignature::Exact(vec![ArrowDataType::UInt32]),
+                    TypeSignature::Exact(vec![ArrowDataType::UInt64]),
+                ],
+                Volatility::Stable,
+            ),
+            ctx,
+        }
+    }
+}
+
+impl std::fmt::Debug for PgGetIndexDef {
+    /// Format without the (non-Debug) session context.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PgGetIndexDef").finish()
+    }
+}
+
+impl PartialEq for PgGetIndexDef {
+    /// Two instances are equal when they share the same session context.
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.ctx, &other.ctx)
+    }
+}
+
+impl Eq for PgGetIndexDef {}
+
+impl std::hash::Hash for PgGetIndexDef {
+    /// Hash by the identity of the shared session context.
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        (Arc::as_ptr(&self.ctx) as usize).hash(state);
+    }
+}
+
+impl ScalarUDFImpl for PgGetIndexDef {
+    /// The schema-qualified function name.
+    fn name(&self) -> &str {
+        "pg_catalog.pg_get_indexdef"
+    }
+
+    /// The accepted argument signature (a single OID).
+    fn signature(&self) -> &Signature {
+        &self.sig
+    }
+
+    /// `pg_get_indexdef` returns the `CREATE INDEX` text as `text`.
+    fn return_type(&self, _arg_types: &[ArrowDataType]) -> Result<ArrowDataType> {
+        Ok(ArrowDataType::Utf8)
+    }
+
+    /// Decode every row's index OID, resolve the DISTINCT ones with a small,
+    /// fixed number of catalog queries, then emit the `CREATE INDEX` text per row
+    /// (NULL where the OID is NULL, unknown, or a functional/partial index).
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+        let arrays = ColumnarValue::values_to_arrays(&args.args)?;
+        let arr = &arrays[0];
+        let len = arr.len();
+
+        let mut oids: Vec<Option<i64>> = Vec::with_capacity(len);
+        for i in 0..len {
+            oids.push(oid_at(arr, i)?);
+        }
+
+        let mut distinct: Vec<i64> = oids.iter().flatten().copied().collect();
+        distinct.sort_unstable();
+        distinct.dedup();
+        let defs = fetch_index_definitions(self.ctx.clone(), &distinct)?;
+
+        let mut builder = StringBuilder::with_capacity(len, 64 * len.max(1));
+        for oid in oids {
+            match oid.and_then(|oid| defs.get(&oid)) {
+                Some(def) => builder.append_value(def),
+                None => builder.append_null(),
+            }
+        }
+        Ok(ColumnarValue::Array(Arc::new(builder.finish()) as ArrayRef))
+    }
+}
+
+/// Register `pg_get_indexdef(oid)`, which reconstructs the `CREATE INDEX` text
+/// for a plain index from live catalog rows. Functional/partial indexes return
+/// NULL until their expression text is integration-supplied (Phase 2).
+pub fn register_pg_get_indexdef(ctx: &SessionContext) -> Result<()> {
+    let udf = ScalarUDF::new_from_impl(PgGetIndexDef::new(Arc::new(ctx.clone())))
+        .with_aliases(["pg_get_indexdef"]);
     ctx.register_udf(udf);
     Ok(())
 }
@@ -3561,6 +3881,40 @@ mod tests {
     use datafusion::datasource::MemTable;
     use datafusion::error::Result;
     use std::sync::Arc;
+
+    #[test]
+    fn test_render_create_index_statement() {
+        // Unique multi-column index, schema-qualified table, matching the
+        // real-PostgreSQL pg_get_indexdef text reproduced in pg_indexes.
+        assert_eq!(
+            render_create_index_statement(
+                true,
+                "pg_proc_proname_args_nsp_index",
+                "pg_catalog",
+                "pg_proc",
+                "btree",
+                &[
+                    "proname".to_string(),
+                    "proargtypes".to_string(),
+                    "pronamespace".to_string(),
+                ],
+            ),
+            "CREATE UNIQUE INDEX pg_proc_proname_args_nsp_index ON pg_catalog.pg_proc \
+             USING btree (proname, proargtypes, pronamespace)"
+        );
+        // Non-unique single-column index omits the UNIQUE keyword.
+        assert_eq!(
+            render_create_index_statement(
+                false,
+                "pg_index_indrelid_index",
+                "pg_catalog",
+                "pg_index",
+                "btree",
+                &["indrelid".to_string()],
+            ),
+            "CREATE INDEX pg_index_indrelid_index ON pg_catalog.pg_index USING btree (indrelid)"
+        );
+    }
 
     #[test]
     fn test_pg_numeric_precision_formula() {

--- a/tests/lazy_pg_catalog.rs
+++ b/tests/lazy_pg_catalog.rs
@@ -7,9 +7,9 @@ use arrow::array::Array;
 use datafusion::error::{DataFusionError, Result as DFResult};
 use datafusion_pg_catalog::{
     get_base_session_context, get_base_session_context_with_lazy_catalog, register_lazy_catalog,
-    register_user_database_with_callback, ColumnSpec, ConfigSettingDef, DatabaseDef, IndexDef,
-    LazyCatalogOptions, LazyCatalogSource, LazyDatabaseRow, RelationDef, RelationKind, SchemaDef,
-    SettingDef,
+    register_user_database_with_callback, ColumnSpec, ConfigSettingDef, ConstraintDef, DatabaseDef,
+    IndexDef, LazyCatalogOptions, LazyCatalogSource, LazyDatabaseRow, RelationDef, RelationKind,
+    SchemaDef, SettingDef,
 };
 
 /// Collect a single-column `StringArray` result into a `Vec<String>`.
@@ -25,6 +25,33 @@ async fn string_column(
             .as_any()
             .downcast_ref::<arrow::array::StringArray>()
             .expect("expected a Utf8 column");
+        for i in 0..arr.len() {
+            if arr.is_valid(i) {
+                out.push(arr.value(i).to_string());
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Collect a single-column text result into a `Vec<String>`, casting whatever
+/// string representation the engine returns (`Utf8`, `LargeUtf8`, `Utf8View`, a
+/// dictionary, ...) to `Utf8` first. Use this for catalog columns whose Arrow
+/// string flavor is not guaranteed (e.g. the `"char"` `contype`, or values that
+/// pass through `information_schema` domain casts).
+async fn text_column(
+    ctx: &datafusion::execution::context::SessionContext,
+    sql: &str,
+) -> DFResult<Vec<String>> {
+    let batches = ctx.sql(sql).await?.collect().await?;
+    let mut out = Vec::new();
+    for b in &batches {
+        let utf8 = arrow::compute::cast(b.column(0), &arrow::datatypes::DataType::Utf8)
+            .expect("a single-column text result must cast to Utf8");
+        let arr = utf8
+            .as_any()
+            .downcast_ref::<arrow::array::StringArray>()
+            .expect("cast result must be a Utf8 StringArray");
         for i in 0..arr.len() {
             if arr.is_valid(i) {
                 out.push(arr.value(i).to_string());
@@ -683,7 +710,11 @@ impl LazyCatalogSource for IndexedSource {
         _r: &str,
         callback: &mut dyn FnMut(Vec<ColumnSpec>),
     ) -> DFResult<()> {
-        callback(vec![ColumnSpec::new("id", 23, false)]);
+        // 'id' (no default) and 'note' (has a default expression).
+        callback(vec![
+            ColumnSpec::new("id", 23, false),
+            ColumnSpec::new("note", 25, true).with_default(),
+        ]);
         Ok(())
     }
 
@@ -699,6 +730,27 @@ impl LazyCatalogSource for IndexedSource {
             idx.is_unique = true;
             idx.is_primary = true;
             callback(vec![idx]);
+        }
+        Ok(())
+    }
+
+    fn constraints(
+        &self,
+        database: &str,
+        schema: &str,
+        callback: &mut dyn FnMut(Vec<ConstraintDef>),
+    ) -> DFResult<()> {
+        if database == "idxdb" && schema == "public" {
+            // A primary key on column 1 ('id') of 'indexed', backed by the
+            // indexed_pkey unique index (oid 80300). Schema oid is 80100.
+            callback(vec![ConstraintDef::primary_key(
+                80400,
+                "indexed_pkey",
+                80100,
+                80200,
+                vec![1],
+                80300,
+            )]);
         }
         Ok(())
     }
@@ -759,6 +811,113 @@ async fn test_lazy_pg_index_reflects_source() -> DFResult<()> {
     )
     .await?;
     assert_eq!(indkey, vec![1], "indkey must list the indexed attnum");
+
+    // pg_get_indexdef templates the CREATE INDEX text from those structural rows
+    // (unique flag, btree access method, schema-qualified table, key column name).
+    let indexdef = string_column(
+        &ctx,
+        "SELECT pg_catalog.pg_get_indexdef(80300)",
+    )
+    .await?;
+    assert_eq!(
+        indexdef,
+        vec!["CREATE UNIQUE INDEX indexed_pkey ON public.indexed USING btree (id)".to_string()],
+        "pg_get_indexdef must reconstruct the CREATE INDEX text for a registered index"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_lazy_pg_constraint_reflects_source() -> DFResult<()> {
+    // A constraint reported by the source becomes a pg_constraint row, and the
+    // (now live) information_schema constraint views derive from it.
+    let (ctx, _log) = get_base_session_context_with_lazy_catalog(
+        Some("pg_catalog_data/pg_schema"),
+        "pgtry".to_string(),
+        "public".to_string(),
+        None,
+        Arc::new(IndexedSource),
+        LazyCatalogOptions::all(),
+    )
+    .await?;
+
+    // The pg_constraint structure row is a primary key over the 'indexed' table.
+    let contype = text_column(
+        &ctx,
+        "SELECT contype FROM pg_catalog.pg_constraint \
+         WHERE conname = 'indexed_pkey' AND conrelid = 80200",
+    )
+    .await?;
+    assert_eq!(contype, vec!["p".to_string()], "pg_constraint must hold the PK");
+
+    // The live table_constraints view reflects the registered constraint.
+    let constraint_types = text_column(
+        &ctx,
+        "SELECT constraint_type FROM information_schema.table_constraints \
+         WHERE table_name = 'indexed' AND constraint_name = 'indexed_pkey'",
+    )
+    .await?;
+    assert_eq!(
+        constraint_types,
+        vec!["PRIMARY KEY".to_string()],
+        "table_constraints must show the registered primary key"
+    );
+
+    // key_column_usage maps the constraint to its column ('id').
+    let key_columns = text_column(
+        &ctx,
+        "SELECT column_name FROM information_schema.key_column_usage \
+         WHERE constraint_name = 'indexed_pkey' AND table_name = 'indexed'",
+    )
+    .await?;
+    assert_eq!(
+        key_columns,
+        vec!["id".to_string()],
+        "key_column_usage must map the PK to column 'id'"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_lazy_pg_attrdef_reflects_source() -> DFResult<()> {
+    // A column flagged with a default becomes atthasdef on pg_attribute plus a
+    // backing pg_attrdef row, while a column without one gets neither.
+    let (ctx, _log) = get_base_session_context_with_lazy_catalog(
+        Some("pg_catalog_data/pg_schema"),
+        "pgtry".to_string(),
+        "public".to_string(),
+        None,
+        Arc::new(IndexedSource),
+        LazyCatalogOptions::all(),
+    )
+    .await?;
+
+    // 'note' (attnum 2) has a default: atthasdef true and a pg_attrdef row.
+    let with_default = ctx
+        .sql(
+            "SELECT 1 FROM pg_catalog.pg_attribute \
+             WHERE attrelid = 80200 AND attname = 'note' AND atthasdef = true",
+        )
+        .await?
+        .count()
+        .await?;
+    assert_eq!(with_default, 1, "the defaulted column must set atthasdef");
+
+    let attrdef_for_note = ctx
+        .sql("SELECT 1 FROM pg_catalog.pg_attrdef WHERE adrelid = 80200 AND adnum = 2")
+        .await?
+        .count()
+        .await?;
+    assert_eq!(attrdef_for_note, 1, "the defaulted column must get a pg_attrdef row");
+
+    // 'id' (attnum 1) has no default, so no pg_attrdef row - the table has exactly
+    // the one pg_attrdef row, for 'note'.
+    let attrdef_total = ctx
+        .sql("SELECT 1 FROM pg_catalog.pg_attrdef WHERE adrelid = 80200")
+        .await?
+        .count()
+        .await?;
+    assert_eq!(attrdef_total, 1, "only the defaulted column gets a pg_attrdef row");
     Ok(())
 }
 

--- a/tests/test_view_output_snapshot.py
+++ b/tests/test_view_output_snapshot.py
@@ -99,7 +99,6 @@ KNOWN_CONTENT_MISMATCHES = {
     "information_schema.views": "view_definition/is_updatable: pg_get_viewdef not reproduced",
     "information_schema.check_constraints": "check_clause: raw node-tree, pg_get_constraintdef not reproduced",
     "pg_catalog.pg_views": "definition: pg_get_viewdef not reproduced",
-    "pg_catalog.pg_indexes": "indexdef: pg_get_indexdef not reproduced",
     "pg_catalog.pg_rules": "definition: pg_get_ruledef not reproduced",
     # After stripping the demo `users` rows the COUNT matches exactly; the only
     # remaining content gap is is_updatable on 4 columns - the


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Catalog constraints and columns with defaults now appear in live metadata views.
  * `pg_get_indexdef` now returns reconstructed `CREATE INDEX` text for standard indexes.
  * More catalog views are now served as live, up-to-date data.

* **Bug Fixes**
  * Improved handling of index definitions and catalog visibility.
  * Defaulted columns and constraint metadata now show the expected system table details.

* **Tests**
  * Expanded coverage for constraints, defaults, and index definition output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->